### PR TITLE
Convert toolbox to SFM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # Editor configuration, see https://editorconfig.org
 root = true
 
-[*.{js,ts}]
+[*.{js,ts,json}]
 charset = utf-8
 indent_style = space
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist/
 
 # Published artifacts
 deploy/
+
+# Output
+*.SFM

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
         "${workspaceFolder}/dist/**.js"
       ],
       "args": [
-        "-j", "D:\\src\\sfm-utils\\samples\\56TIT.json"
+        "-p", "slt",
+        //"-j", "C:\\src\\sfm-utils\\samples\\56TIT.json"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -1,48 +1,33 @@
 
 # sfm-utils
 Utilities to parse text files (e.g. from Toolbox) and migrate SFM markers into a format suitable for Paratext.
+Each book input is written to individual .sfm files.
+
+Assumptions:
+* Toolbox text files contain Windows line-endings
+* Each text file is for a single chapter of a book
+* Each directory of files is for a single book
+* Text filenames consist of a bookname separated by space/underscore with the chapter number (e.g. Judges_19...txt)
 
 ## Usage
 Note for developers: Replace `sfm-utils.exe` references with `node dist/index.js`.
 
------
-### Project name
 Command-line
 ```bash
-sfm-utils.exe
+Usage: sfm-utils.exe -p p_arg [-t t_arg | -d d_arg | -j j_arg | -s s_arg]
+```
+
+Parameters
+```bash
+    Required
     -p [Paratext project name (can be 3-character abbreviation)]
+
+    Optional - one of:
+    -t [A single Toolbox text file (one chapter of a book)]
+    -d [Directory of Toolbox text files for a single book (one chapter per file)]
+    -j [JSON file representing a single book - used for testing conversion to SFM]
+    -s [Directory of directories (each subdirectory is a separate book)]
 ```
-
-This parameter is required and used with the optional parameters below.
-
-### Convert a single text file
-
-Command-line
-```bash
-sfm-utils.exe
-    -t [path to txt file]
-```
-
-### Convert all the text files in a directory
-
-Command-line
-```bash
-sfm-utils.exe
-    -d [path to folders of txt files]
-```
-
-### JSON Book status file for testing
-
-Command-line:
-```bash
-sfm-utils.exe
-    -j [path to JSON status file] 
-```
-
-This reads in the JSON file and writes out the corresponding .SFM file for the book
-
------
-
 
 ### Help
 Obtaining the sfm-utils version:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Utilities to parse text files (e.g. from Toolbox) and migrate SFM markers into a
 Note for developers: Replace `sfm-utils.exe` references with `node dist/index.js`.
 
 -----
+### Project name
+Command-line
+```bash
+sfm-utils.exe
+    -p [Paratext project name (can be 3-character abbreviation)]
+```
+
+This parameter is required and used with the optional parameters below.
 
 ### Convert a single text file
 
@@ -23,10 +31,7 @@ sfm-utils.exe
     -d [path to folders of txt files]
 ```
 
-### JSON Book file
-The JSON book file has a name
-
-### Use a JSON status file for testing
+### JSON Book status file for testing
 
 Command-line:
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Utilities to parse text files (e.g. from Toolbox) and migrate SFM markers into a
 Each book input is written to individual .sfm files.
 
 Assumptions:
-* Toolbox text files contain Windows line-endings
 * Each text file is for a single chapter of a book
 * Each directory of files is for a single book
 * Text filenames consist of a bookname separated by space/underscore with the chapter number (e.g. Judges_19...txt)

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,40 @@
+# Design for Parsing Toolbox Text Files
+
+There are two modes for parsing the .txt files in [toolbox.ts](../src/toolbox.ts) into a JSON Object based on how the `\tx` and `\vs` markers are used in the file.
+The regex splits each line into `marker` and `content`:
+* `TX_AS_VERSE`: Each `\tx` marker creates a new verse, `\vs` is only used for section header
+* `VS_AS_VERSE`: `\vs` marks verse numbers along with section headers. Uses the state machine below:
+
+```typescript
+/**
+ * States for VS_AS_VERSE processing mode
+ */
+type actionType =
+  "START" |                   // Initial state
+  "CREATE_NEW_VERSE" |        // Create new verse entry and push to content[]
+  "APPEND_TO_VERSE" |         // Append current content to last verse
+  "INCREMENT_VERSE_NUM" |     // Increment verseNum (current verse counter)
+  "MODIFY_VERSE_TO_SECTION" | // Change last type from verse to section section
+  "MERGE_VERSES";             // Merge the last two verses, set number = verseNum - 1
+                              // This handles \vs 13b, \vs 13c, etc.
+```
+
+If the marker is `\vs`, theres 2 additional booleans to determine special cases:
+* `vs_other` - The `\vs` marks a verse #-other letter besides "a"
+* `vs_section_header` - The `\vs` marks a section header (section title)
+
+## State machine of the actions and markers
+```mermaid
+flowchart TD
+    A[START] -- \tx --> B[CREATE_NEW_VERSE];
+    B -- vs_section_header --> E[MODIFY_VERSE_TO_SECTION];
+    E -- \tx --> B;
+    B -- \tx --> C[APPEND_TO_VERSE];
+    C -- \tx --> C;
+    C -- \vs --> D[INCREMENT_VERSE_NUM];
+    D -- \tx --> B;
+    B -- \vs --> D;
+    C -- \vs_other --> F[MERGE_VERSES];
+    F -- \tx --> B;
+    B -- vs_other --> F;
+```

--- a/samples/50PHP-2.json
+++ b/samples/50PHP-2.json
@@ -1,0 +1,418 @@
+  [
+    {
+      "type": "chapter",
+      "number": 2,
+      "content": [
+        {
+          "type": "verse",
+          "number": 1,
+          "text": "còo pɛ́ɛ/ kóoy rɛ̀ɛŋ tìˑ ntè/ pʰra/ kʰrístòoʔ àn ò̬o̬y pɛ́ɛ/ ɛ́h rəlò̬/ ràhʔ ɛ̀/ rùum mɛ̀h nẁm òh kwlpò/ʔ àn kàh pɛ́ɛ/ kóoy rəlò̬/ ràk rəlò̬/ ha/ámʔ"
+        },
+        {
+          "type": "verse",
+          "number": 2,
+          "text": "mɔ́ɔ pɛ́ɛ/ kóoy plɔ́/ kàh o/ lɔ̀k pʰéem, kóoy rəlò̬/ ràk tʰrikẁt simə̀ə pò̬/. bɛ́ɛŋ pán rəlò̬/ ràk simə̀ə pò̬/. kóoy kamkẁt panñàa mɛ̀h nẁm mòh ritìŋ."
+        },
+        {
+          "type": "verse",
+          "number": 3,
+          "text": "yẁm pɛ́ɛ/ plɔ́/ lɔ̀k, tʰáa kàh i/ tʰrikẁt lɔ̀k nẁm lɔ̀ŋ pɛ́ɛ/. kàh pɛ́ɛ/ noom tóo tì/ ŋòot ntrùum i/ kipò̬/ lɔ̀k lə́ə."
+        },
+        {
+          "type": "verse",
+          "number": 4,
+          "text": "tʰáa ñoot tʰáa mẃŋ nẁm tóo tì/ mòh i/. tɛ̀ɛ kàh pɛ́ɛ/ lɔ̀k pʰéem tìˑ còo i/ kipò̬/ dɛ́ɛ."
+        },
+        {
+          "type": "verse",
+          "number": 5,
+          "text": "tìˑ còo pɛ́ɛ/, pɛ́ɛ/ cìi.tò̬o̬ŋ tʰrikẁt kàh àn mɛ̀ɛn cá/ pʰra/yesúu kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 6,
+          "text": "tìˑ tóo pʰra/ kʰrístòo kùu cẁw àn mɛ̀h cá/ pʰra/pincáv. tɛ̀ɛ àn kóˑ tʰrikẁt lɔ̀ɔ síiŋ tì/ simə̀ə pʰra/pincáv, àn kóˑ mɛ̀h síiŋ tì/ i/ kák, háam."
+        },
+        {
+          "type": "verse",
+          "number": 7,
+          "text": "àn mplàh bɔ́ɔn àn póo pʰra/pincáv, àn plɔ́/ kàh tóo tì/ okóoy mɛ̀h. àn kẃwt mɛ̀h hi/ùuñ, mɛ̀h cá/ kɔ́ɔn tiké/ i/."
+        },
+        {
+          "type": "verse",
+          "number": 8,
+          "text": "àn noom tóo tì/ ŋòot mɛ̀h hi/ùuñ. àn /yám nàp.tʰẃw pʰra/pincáv cò̬n àn yàm ŋòot tìˑ kʰé/ kaykéeŋ."
+        },
+        {
+          "type": "verse",
+          "number": 9,
+          "text": "pʰra/pincáv yok pʰra/ kʰrístòo rɛ̀h tìˑ bɔ́ɔn léeŋ tìi sʊ́t. pʰra/pincáv plɔ́/ kàh cẁw pʰra/ kʰrístòo lɔ̀k lə́ə cẁw cáv i/ kipò̬/."
+        },
+        {
+          "type": "verse",
+          "number": 10,
+          "text": "pʰra/pincáv só/ kàh ntòoc ròoŋ kùu i/ tìˑ ntè/ mə̀əŋ savàn twmúum nòp.və́y pʰra/yesúu, hi/i/ tì/ ŋkáal lòok anɔ̀h tɔ́ŋ.ác póˑ tìˑ ntrùum lòok."
+        },
+        {
+          "type": "verse",
+          "number": 11,
+          "text": "kùu i/ cìi lɔ̀ɔ pʰra/yesúu mɛ̀h pʰa/cáv, otòh kiàt otòh ñòt tìˑ ùuñ àn pʰra/pincáv."
+        },
+        {
+          "type": "section",
+          "number": 1,
+          "text": "kàh pɛ́ɛ/ mɛ̀h hi/i/ tì/ pʰra/pincáv só/ kàh pɛ́ɛ/ mɛ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 12,
+          "text": "po/ pẁwŋ tì/ o/ ràk, pɛ́ɛ/ tì/ kẁwy /yám nàp.tʰẃw pʰra/pincáv yẁm o/ nɔ́ɔŋ ŋòot póˑ pɛ́ɛ/. kíi.mɛ̀h nẁm pwl/ə̀h mɔ̀/ àn kò̬o̬ samkʰan tìˑ pɛ́ɛ/. kàh pɛ́ɛ/ /yám nàp.tʰẃw yẁm o/ kóˑ ŋòot póˑ pɛ́ɛ/. kàh pɛ́ɛ/ sicə́y plɔ́/ kàh àn hóoc vèek pʰa/cáv pɛ́ɛ/. àn tì/ próot pənpò̬n. kàh pɛ́ɛ/ láat àn, plɔ́/ kàh àn mɛ̀ɛn pʰéem pʰra/pincáv, tʰáa mpòoy."
+        },
+        {
+          "type": "verse",
+          "number": 13,
+          "text": "əə, pʰra/pincáv àn cò̬o̬y kàh pɛ́ɛ/ plɔ́/ mɛ̀h mɛ̀h tì/ àn só/ kàh pɛ́ɛ/ plɔ́/ mɛ̀ɛn tìˑ àn."
+        },
+        {
+          "type": "verse",
+          "number": 14,
+          "text": "kàh pɛ́ɛ/ plɔ́/ kùu cẁw. tʰáa mpòoy, tʰáa pʰít pò̬/.tì/."
+        },
+        {
+          "type": "verse",
+          "number": 15,
+          "text": "i/ cìi kóˑ lɔ̀ɔ pɛ́ɛ/ mɛ̀h hi/i/ okóoy pəñòot. tʰáa kàh i/ lɔ̀ɔ pɛ́ɛ/ kóoy pʰít. pɛ́ɛ/ cìi pèen.tì/ mɛ̀h kɔ́ɔn pʰra/pincáv tì/ okóoy pʰít mɛ̀h. tɛ̀ɛ pɛ́ɛ/ ŋòot póˑ i/ tì/ ñàŋ rəmpò̬h pʰéem vok, hi/i/ kèe/ anɔ̀h tɔ́ŋ.ác tì/ ŋòot véet ò̬o̬m pɛ́ɛ/. kèe/ mɛ̀h hi/i/ kóˑ lɔ̀k tìˑ ntè/ pẁwŋ pɛ́ɛ/. pɛ́ɛ/ mɛ̀h cá/ rimìñ pɔ̀h, sɔ́ɔŋ tìˑ ntè/ lòok ɔ̀p."
+        },
+        {
+          "type": "verse",
+          "number": 16,
+          "text": "pɛ́ɛ/ tòh rɔ́ɔ tì/ prán sɔ́ɔn, kàh kèe/ ɛ́h còo bɔ́h yẁm pʰra/ kʰrístòo cìi cùa tòh tʰɛ́ɛm, o/ lɔ̀k pʰéem, ñò̬o̬n vèek o/ àn kóˑ mɛ̀h vèek píc dẃp. o/ tàav pɛ̀ɛv i/ tìˑ bɔ́ɔn i/ tàav."
+        },
+        {
+          "type": "verse",
+          "number": 17,
+          "text": "rəlò̬/ pɛ́ɛ/ tẁwm àn plɔ́/ kàh còo pɛ́ɛ/ mɛ̀h cá/ kʰɔ́ŋ i/ tàan təváay tìˑ pʰra/pincáv. o/ cìi təváay tóo náam o/ póˑ kʰɔ́ŋ tì/ pɛ́ɛ/ tàan təváay. tɛ̀ɛ mɔ́ɔ anɛ̀h kẃwt yàav, ntè/ pʰéem o/ cìi sʊ́ʊs, nòok nẁm rəlò̬/ lɔ̀k rəlò̬/ rẃwm póˑ pɛ́ɛ/ tɔ́ŋ.ác."
+        },
+        {
+          "type": "verse",
+          "number": 18,
+          "text": "tìˑ pʰéem pɛ́ɛ/ kò̬o̬ kʰùan tì/ nòok nẁm rəlò̬/ lɔ̀k rəlò̬/ rẃwm póˑ o/."
+        },
+        {
+          "type": "section",
+          "number": 1,
+          "text": "lɔ̀ɔ lə̀əŋ timotiɛ̀v póˑ èe/pafòkhi."
+        },
+        {
+          "type": "verse",
+          "number": 19,
+          "text": "o/ vɔ́ŋ lɔ̀ɔ pʰra/pincáv cìi tóol timòtiɛ̀v tòh tìˑ pɛ́ɛ/ sitə̀əm. o/ cìi lɔ̀k pʰéem tì/ sɔ́ŋ lɔ̀ɔ pɛ́ɛ/ yèh mwn.mɔ̀/."
+        },
+        {
+          "type": "verse",
+          "number": 20,
+          "text": "o/ okóoy mɔ̀/ tì/ mɛ̀h cá/ timòtiɛ̀v. àn càat.mɛ̀ɛ sicə́y pɛ́ɛ/ ñìh."
+        },
+        {
+          "type": "verse",
+          "number": 21,
+          "text": "hi/i/ i/ kipò̬/ kèe/ lɔ̀k pʰéem nẁm tìˑ còo kèe/. kèe/ kóˑ lɔ̀k pʰéem tì/ plɔ́/ vèek tìˑ ntè/ còo pʰra/ kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 22,
+          "text": "pɛ́ɛ/ sɔ́ŋ lɔ̀ɔ timòtiɛ̀v àn mɛ̀h hi/i/ cá/ amɔ̀/. pɛ́ɛ/ kò̬o̬ sɔ́ŋ lɔ̀ɔ àn ác plɔ́/ vèek cò̬o̬y o/. àn páav kʰáav lɔ̀k kʰáav bɔ́h, cá/ kɔ́ɔn cò̬o̬y ùuñ."
+        },
+        {
+          "type": "verse",
+          "number": 23,
+          "text": "o/ cìi pʰrooŋ tì/ tóol kàh àn tòh tìˑ pɛ́ɛ/ və̀əy və̀əy. yẁm o/ cìi sɔ́ŋ lɔ̀ɔ àn kẃwt mɛ̀h yàav mɛ̀h tìˑ o/."
+        },
+        {
+          "type": "verse",
+          "number": 24,
+          "text": "o/ nɛ́ɛ/ ñìh lɔ̀ɔ pʰra/pincáv cìi cò̬o̬y kàh o/ tòh tìˑ pɛ́ɛ/ sitə̀əm."
+        },
+        {
+          "type": "verse",
+          "number": 25,
+          "text": "èe/pafòdiò, àn mɛ̀h yò/ ɛ̀ɛk o/ tìˑ ntè/ pʰra/ kʰrístòo. yẁm o/ tò̬o̬ŋkáan cò̬o̬y, pɛ́ɛ/ tóol àn tìˑ o/. pwl/ə̀h o/ tʰrikẁt lɔ̀ɔ o/ cìi.tò̬o̬ŋ tóol kàh àn kláay tìˑ pɛ́ɛ/."
+        },
+        {
+          "type": "verse",
+          "number": 26,
+          "text": "ñò̬o̬n àn càat.mɛ̀ɛ só/ tàm pɛ́ɛ/ kùu i/. àn pinhúaŋ ñò̬o̬n pɛ́ɛ/ àm lɔ̀ɔ àn mɛ̀h hi/i/ só/."
+        },
+        {
+          "type": "verse",
+          "number": 27,
+          "text": "əə/, mɛ̀h ñìh lɛ̀/. àn só/ nɔ́ɔŋ nò/ cìi yàm. tɛ̀ɛ pʰra/pincáv cò̬o̬y àn, póˑ o/ dɛ́ɛ. kóˑ kàh o/ kico/ pʰéem màak tʰɛ́ɛm."
+        },
+        {
+          "type": "verse",
+          "number": 28,
+          "text": "o/ càat.mɛ̀ɛ só/ tóol kàh àn kláay tòh tìˑ pɛ́ɛ/. yẁm pɛ́ɛ/ tàm àn pɛ́ɛ/ cìi lɔ̀k pʰéem, o/ cìi /yʊ́t kóˑ pinhúaŋ lə̀əŋ pɛ́ɛ/."
+        },
+        {
+          "type": "verse",
+          "number": 29,
+          "text": "kàh pɛ́ɛ/ lɔ̀k pʰéem tìˑ pʰra/pincáv, ràp tò̬o̬m àn /yám nàp.tʰẃw, ràk hi/i/ cá/ èe/pafòditò."
+        },
+        {
+          "type": "verse",
+          "number": 30,
+          "text": "àn kʰùan tì/ mɛ̀h hi/i/ tì/ i/ nàp.tʰẃw, nɔ́ɔŋ nò/ àn cìi yàm ñò̬o̬n àn plɔ́/ vèek pʰra/ kʰrístòo, àn ro/ còo àn tìˑ bɔ́ɔn i/ láat, kàh àn pèen.tì/ cò̬o̬y o/. anɔ̀h mɛ̀h vèek tì/ pɛ́ɛ/ cò̬o̬y o/ kóˑ pèen."
+        }
+      ]
+    },
+    {
+      "type": "chapter",
+      "numnber": 3,
+      "content": [
+        {
+          "type": "section",
+          "number": 1,
+          "text": "síiŋ tì/ samkʰán samlàp pʰra/ kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 1,
+          "text": "yò/ ɛ̀ɛk tì/ o/ ràk, rɔ́ɔ kàh pɛ́ɛ/ kóoy rəlò̬/ lɔ̀k rəlò̬/ rẃwm nòok tóo tìˑ ntè/ pʰra/pincáv. àn cìi okóoy banháa mɛ̀h tʰɛ́ɛm, samlàp o/ tii kʰiɛ́n nàŋsẃw anɔ̀h tòh tìˑ pɛ́ɛ/ cá/ yẁm pò̬h. àn cìi cò̬o̬y kàh pɛ́ɛ/ pʰràp tóo tì/ ŋòot kɔ́ɔ/."
+        },
+        {
+          "type": "verse",
+          "number": 2,
+          "text": "kàh pɛ́ɛ/ lavɔ̀ŋ hi/i/ kèe/ anɔ̀h mɔ̀/ tì/ plɔ́/ sùa. kèe/ lɔ̀ɔ kèe/ mɛ̀h hi/i/ ràb sín tát."
+        },
+        {
+          "type": "verse",
+          "number": 3,
+          "text": "tɛ̀ɛ ñìh àn mɛ̀h yèe/ tì/ ràb sín tàt. yèe/ nòp.və́y kwlpò/ pʰra/pincáv. yèe/ pɔ̀h ŋàay ɛ́h yèe/ pèen.tì/ ŋòot tìˑ ntè/ pʰra/yesúu kʰrístòo. yèe/ tẁwm tìˑ ntè/ tóo yèe/ póo vèek kùu cẁw tii plɔ́/."
+        },
+        {
+          "type": "verse",
+          "number": 4,
+          "text": "kíi.mɛ̀h nẁm tìˑ ntè/ tóo o/ mɔ̀/, o/ kò̬o̬ nɔ́ɔŋ kóˑ sáay tẁwm. mɔ́ɔ mɔ̀/ lɔ̀ɔ àn hɔ́k tẁwn nẁn tìˑ ntè/ tóo tì/ mòh i/. àn kʰùan tì/ sɔ́ŋ lɔ̀ɔ, o/ kóoy rəlò̬/ tẁwm tìˑ ntè/ tóo o/ màak lə́ə àn anɛ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 5,
+          "text": "o/ mɛ̀h i/ tì/ ràb sín tát, tá/ siŋì/ vàay o/ kẃwt lèh, o/ mɛ̀h i/ tì/ kɛ́h píc hi/i/ isra/ɛ̀ɛn, cẁa.càat lɔ̀ŋ binyamìn. o/ mɛ̀h hi/i/ hiprə́ə, nèe/ ùuñ o/ mɛ̀h hi/i/ hiprə́ə. kó̬t.máay mosɛ̀ɛ àn samkʰán samlàp o/. àn kẃwt yàav cá/ anɛ̀h, o/ taa.tìi mɛ̀h hi/i/ farisàay."
+        },
+        {
+          "type": "verse",
+          "number": 6,
+          "text": "yẁm./ə̀h o/ mɛ̀h i/ tì/ kóoy pʰéem roon, o/ pooŋ tì/ pẁnsó/ hi/i/ sasáʼna, plɔ́/ kàh kèe/ só/ pʰéem. okóoy mɔ̀/ pẁp, tàm lɔ̀ɔ àn pʰít mɛ̀h lɔ̀ŋ o/ /yám nàp.tʰẃw, tòoy táam kó̬t.máay mosɛ̀ɛ."
+        },
+        {
+          "type": "verse",
+          "number": 7,
+          "text": "àn mɛ̀h nẁm mòh cèeŋ síiŋ kèe/ anɔ̀h tɔ́ŋ.ác, mɛ̀h síiŋ tì/ samkʰán samlàp o/. tɛ̀ɛ pwl/ə̀h o/ tʰrikẁt lɔ̀ɔ, síiŋ kèe/ anɔ̀h àn okóoy pəñòot mɛ̀h ñò̬o̬n pʰra/ kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 8,
+          "text": "àn kóˑ mɛ̀h nẁm síiŋ kèe/ anɔ̀h tʰántɛ̀h. tɛ̀ɛ o/ tʰrikẁt lɔ̀ɔ, síiŋ kèe/ anɔ̀h tɔ́ŋ.ác, kèe/ okóoy pəñòot mɛ̀h tẃmno/ mɔ̀/. tii mɛ̀h síiŋ tì/ piɛ́b pèen póˑ síiŋ tì/ o/ sɔ́ŋ samlàp pʰra/ kʰrístòo pʰa/cáv ɛ̀/. ñò̬o̬n pʰra/ kʰrístòo anɛ̀h lɛ/. o/ taa.tìi píc síiŋ kʰɔ́ŋ kèe/ anɛ̀h tɔ́ŋ.ác. pwl/ə̀h o/ sɔ́ŋ lɔ̀ɔ, síiŋ kèe/ anɛ̀h tɔ́ŋ.ác àn okóoy pəñòot mɛ̀h. àn mɛ̀h nẁm síiŋ tì/ i/ píc tì/ prʼyàh. o/ mblàh kàh o/ pèen.tì/ ɛ́h pʰra/ kʰrístòo, àn tì/ kóoy pəñòot samlàp o/."
+        },
+        {
+          "type": "verse",
+          "number": 9,
+          "text": "pwl/ə̀h o/ mɛ̀h ɛ́h àn. o/ mɛ̀h lɔ̀ŋ pʰra/ kʰrístòo, o/ mɛ̀ɛn pó pʰra/pincáv. lɔ̀ŋ àn rɛ̀ɛk tì/ mɛ̀ɛn anɔ̀h, àn kóˑ tòh píc kó̬t.máay lɔ̀ŋ o/ tòoy. àn tòh píc rəlò̬/ o/ tẁwm pʰra/pincáv. pʰra/pincáv àn cày rəlò̬/ tì/ o/ tẁwm píc pʰra/ kʰrístòo, plɔ́/ kàh o/ mɛ̀ɛn pó àn."
+        },
+        {
+          "type": "verse",
+          "number": 10,
+          "text": "síiŋ tì/ o/ só/ sɔ́ŋ tɔ́ŋ.ác, àn mɛ̀h sít amnàat rɛ̀ɛŋ kʰɔ̀ŋ pʰra/ kʰrístòo tì/ kɛ́h kláay píc rəmyàm. àn mɛ̀h o/ só/ bɛ̀ɛŋ pán, rùum tok təəl anɛ̀h póˑ àn, yàav cá/ rəmyàm àn."
+        },
+        {
+          "type": "verse",
+          "number": 11,
+          "text": "mɔ́ɔ o/ kóoy síiŋ kèe/ anɔ̀h. o/ vɔ́ŋ lɔ̀ɔ, vàay si/ə̀h, tóo o/ cìi kɛ́h kláay ìim píc rəmyàm cá/ àn."
+        },
+        {
+          "type": "verse",
+          "number": 12,
+          "text": "o/ kóˑ máay lɔ̀ɔ, o/ ác pẃa pʰra/pincáv kàh tóo tì/ mɛ̀h cá/ anɛ̀h. àn mɛ̀h bɔ́ɔn tì/ o/ háay tì/ tòh tìˑ nɛ̀h. tɛ̀ɛ o/ nɔ́ɔŋ prooŋ tì/ tòh tìˑ nɛ̀h, plɔ́/ kàh àn mɛ̀h ɛ́h o/. àn mɛ̀h pʰra/ kʰrístòo tì/ só/ kàh o/ plɔ́/ anɛ̀h, kàh o/ pèen.tì/ mɛ̀h ɛ́h àn."
+        },
+        {
+          "type": "verse",
+          "number": 13,
+          "text": "yò/ ɛ̀ɛk ə̀əy, o/ sɔ́ŋ lɔ̀ɔ o/ háay tì/ tòh tìˑ bɔ́ɔn anɛ̀h. tɛ̀ɛ tìˑ nɛ̀h, àn ác kóoy mòh cẁw mɛ̀h síiŋ tì/ o/ kəəy plɔ́/ píc yẁm./ə̀h. o/ prooŋ tʰán o/ prooŋ pèen. kàh tóo tì/ pò̬n, tòh tìˑ lɔ̀ŋ pò̬h ŋàay vàay si/ə̀h."
+        },
+        {
+          "type": "verse",
+          "number": 14,
+          "text": "o/ prooŋ kàh tì/ pèen kʰɔ́ŋ tì/ kóˑ lakʰàa ŋos lɔ̀ŋ pò̬h ŋàay. ŋos anɛ̀h àn mɛ̀h ɛ́h o/. ñò̬o̬n pʰra/pincáv ác vò̬o̬l o/ tìˑ ntè/ pʰra/yesúu kʰrístòo, kàh o/ ràb tì/ ɛ́h còo tì/ tòh lɔ̀ŋ taléeŋ."
+        },
+        {
+          "type": "verse",
+          "number": 15,
+          "text": "ɛ̀/ tɔ́ŋ.ác mɔ̀/ tì/ ác mɛ̀h hi/i/ lɛ̀h, kʰùan tì/ tʰrikẁt lɔ̀ŋ anɔ̀h dɛ́ɛ. mɔ́ɔ àn kóoy síiŋ tì/ pɛ́ɛ/ kóˑ tókloŋ tìˑ nɛ̀h póˑ kèe/, pʰra/pincáv cìi plɔ́/ kàh àn cɛ́ɛŋ tìˑ kèe/."
+        },
+        {
+          "type": "verse",
+          "number": 16,
+          "text": "tɛ̀ɛ ɛ̀/ kʰùan tì/ tòoy táam rəlò̬/ ñìh tì/ ɛ̀/ ác kóoy."
+        },
+        {
+          "type": "verse",
+          "number": 17,
+          "text": "yò/ ɛ̀ɛk ə̀əy, samlàp pɛ́ɛ/ tɔ́ŋ.ác, kàh pɛ́ɛ/ prooŋ tì/ tòoy. tə́əŋ hi/i/ kèe/ anɔ̀h mɔ̀/ tì/ o/ ác pléh pwnsó̬h kàh pɛ́ɛ/ tàm."
+        },
+        {
+          "type": "verse",
+          "number": 18,
+          "text": "kóoy màak i/ mɛ̀h sat.tùu to̬súu kʰé/ kaykéeŋ kʰɔ̀ŋ pʰra/ kʰrístòo. kóoy báaŋ ràav o/ ác lɔ̀ɔ pɛ́ɛ/ àm lə̀əŋ kèe/. àn plɔ́/ kàh o/ yàam tii o/ lɔ̀ɔ pɛ́ɛ/ àm lə̀əŋ kèe/ pwl/ə̀h."
+        },
+        {
+          "type": "verse",
+          "number": 19,
+          "text": "lɔ̀ŋ kèe/ ŋòot anɛ̀h, àn cìi cò̬o̬y plɔ́/ kàh còo kèe/ làac. kèe/ kʰùan tì/ plɔ́/ vèek lɔ̀ŋ pʰra/pincáv. kèe/ plɔ́/ táam tóo kèe/ só/ ɛ́h. kèe/ lɔ̀k pʰéem tì/ plɔ́/ síiŋ tì/ i/ kimà/ ŋàay. kèe/ tʰrikẁt nẁm lə̀əŋ tì/ lòok anɔ̀h tʰrikẁt."
+        },
+        {
+          "type": "verse",
+          "number": 20,
+          "text": "tɛ̀ɛ yèeŋ ñà/ ɛ̀/ àn mɛ̀h mə̀əŋ savàn, ɛ̀/ ŋòot kɔ́ɔ/ i/ tì/ próot pənpò̬n ɛ̀/, àn mɛ̀h pʰra/ kʰrístòo tì/ tòh píc mə̀əŋ savàn."
+        },
+        {
+          "type": "verse",
+          "number": 21,
+          "text": "àn cìi piyéen tóo ɛ̀/ tì/ mɛ̀h hi/i/ pɛ̀c hi/i/ ñia. kàh ɛ̀/ mɛ̀h hi/i/ lɔ̀k hi/i/ rẃwm cá/ tóo àn. àn mɛ̀h sít amnàat rɛ̀ɛŋ anɛ̀h tì/ plɔ́/ kàh kùu cẁw ŋòot ntrùum àn baŋkʰàp tɔ́ŋ.ác."
+        }
+      ]
+    },
+    {
+      "type": "chapter",
+      "number": 4,
+      "content": [
+        {
+          "type": "section",
+          "number": 1,
+          "text": "hi/i/ sasa/nàa plɔ́/ mɛ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 1,
+          "text": "yò/ ɛ̀ɛk ə̀əy, o/ ràk pɛ́ɛ/ o/ só/ tàm pɛ́ɛ/. pɛ́ɛ/ otòh rəlò̬/ lɔ̀k rəlò̬/ rẃwm plɔ́/ kàh o/ pɔ̀h ŋàay tìˑ pɛ́ɛ/. rɔ́ɔ kàh pɛ́ɛ/ kláay tòoy pʰra/pincáv táam o/ ác lɔ̀ɔ tìˑ pɛ́ɛ/."
+        },
+        {
+          "type": "verse",
+          "number": 2,
+          "text": "o/ rɔ́ɔ tì/ pẃa nàaŋ yùu/òo/dia póˑ nàaŋ sìntìikʰèe, kàh kàa tokloŋ mɛ̀ɛn tìˑ pò̬/.tì/ tìˑ ntè/ pʰra/pincáv."
+        },
+        {
+          "type": "verse",
+          "number": 3,
+          "text": "ñò̬o̬n pɛ́ɛ/ kóoy pʰéem tẁwm cò̬o̬y o/, póˑ po/ o/. o/ rɔ́ɔ tì/ pẃa kàh pɛ́ɛ/ cò̬o̬y anèe/ kàa anɛ̀h plɔ́/ anɔ̀h. kàa mɛ̀h hi/i/ tì/ ác cò̬o̬y o/ lɔ̀ɔ i/ àm lə̀əŋ kʰáav bɔ́h. kàa cò̬o̬y káʼlèenèe póˑ hi/i/ kipò̬/ mɔ̀/ tì/ plɔ́/ vèek póˑ o/. cẁw kèe/ i/ ác kʰyɛ̀ɛn ŋə̀h tìˑ ntè/ pẁwm àn tì/ kóoy còo tẁw okóoy yẁm làac."
+        },
+        {
+          "type": "verse",
+          "number": 4,
+          "text": "lɔ̀ŋ pʰra/pincáv kàh pɛ́ɛ/ nòok nẁm rəlò̬/ lɔ̀k rəlò̬/ rẃwm tẁw. o/ cìi lɔ̀ɔ anɔ̀h tʰɛ́ɛm. rɔ́ɔ kàh pɛ́ɛ/ nòok nẁm rəlò̬/ lɔ̀k rəlò̬/ rẃwm tẁw."
+        },
+        {
+          "type": "verse",
+          "number": 1,
+          "text": "pléh pwnsó̬h kàh i/ tàm tɔ́ŋ.ác lɔ̀ɔ, pɛ́ɛ/ kóoy pʰéem lɔ̀k pʰéem tɛ̀ɛb. pʰra/pincáv ác tòh ntɛ̀/ hóoc."
+        },
+        {
+          "type": "verse",
+          "number": 6,
+          "text": "tʰáa póo tʰrikẁt mɛ̀h kùu cẁw. tɛ̀ɛ kàh pɛ́ɛ/ súat rɔ́ɔ tìˑ pʰra/pincáv kùu cẁw tì/ pɛ́ɛ/ tò̬o̬ŋ káan só/ ɛ́h. yẁm pɛ́ɛ/ súat kàh pɛ́ɛ/ lɔ̀k pʰéem tìˑ pʰra/pincáv tẁw."
+        },
+        {
+          "type": "verse",
+          "number": 7,
+          "text": "hóoc pʰra/pincáv cìi ŋə̀h rəlò̬/ ràk rəlò̬/ rẃwm, kamkẁt panñàa tì/ i/ ràk tùul póˑ pò̬/.tì/ tìˑ ntè/ pʰra/yesúu kʰrístòo. rəlò̬/ lɔ̀k rəlò̬/ rẃwm tì/ pʰra/pincáv kàh, àn lɔ̀k lə́ə síiŋ tì/ ɛ̀/ sɔ́ŋ."
+        },
+        {
+          "type": "verse",
+          "number": 8,
+          "text": "yò/ ɛ̀ɛk ə̀əy, kàh pɛ́ɛ/ kláay tʰrikẁt lɔ̀k pʰéem sʊ́ʊs tìˑ lə̀əŋ lɔ̀k, síiŋ tì/ kóoy làakʰàa màak. tʰrikẁt lə̀əŋ lɔ̀k lə̀əŋ ñìh tì/ i/ /yám nàp.tʰẃw. àn mɛ̀h lə̀əŋ mɛ̀h tì/ lɔ̀k siŋàm, cɛ́ɛŋ cəəs."
+        },
+        {
+          "type": "verse",
+          "number": 9,
+          "text": "kàh pɛ́ɛ/ plɔ́/ mɛ̀h mɛ̀h tì/ pɛ́ɛ/ ác rèen sɔ́ŋ, síiŋ tì/ pɛ́ɛ/ ác ràb píc o/. plɔ́/ mɛ̀h mɛ̀h tì/ o/ lɔ̀ɔ, póˑ mɛ̀h tì/ pɛ́ɛ/ tàm o/ plɔ́/. pʰra/pincáv mɔ̀/ tì/ kàh rəlò̬/ lɔ̀k rəlò̬/ rẃwm cìi ŋòot póˑ pɛ́ɛ/ kùu i/."
+        },
+        {
+          "type": "section",
+          "number": 1,
+          "text": "polòo lɔ̀k pʰéem kʰap.cáy tìˑ hi/i/ sasa/nàa."
+        },
+        {
+          "type": "verse",
+          "number": 10,
+          "text": "o/ lɔ̀k pʰéem tìˑ pʰra/pincáv tì/ pɛ́ɛ/ ác pwnsó̬h kàh o/ tàm lɔ̀ɔ, pɛ́ɛ/ nɔ́ɔŋ mẃŋ sicə́y o/ tʰɛ́ɛm. pɛ́ɛ/ nɔ́ɔŋ kláay mẃŋ sicə́y lə̀əŋ o/. tɛ̀ɛ lɔ̀ŋ pɛ́ɛ/, àn okóoy mɛ̀h tì/ pɛ́ɛ/ plɔ́/ pléh pwnsó̬h kàh i/ tàm tìˑ nɛ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 11,
+          "text": "o/ lɔ̀ɔ pɛ́ɛ/ àm anɔ̀h, tɛ̀ɛ àn kóˑ mɛ̀h ñò̬o̬n o/ tò̬o̬ŋ káan mɛ̀h kùu cẁw. o/ ác rèen sɔ́ŋ, poo pʰéem póˑ kùu cẁw tì/ o/ kóoy, póˑ tii kùu cẁw tì/ kẃwt yáav."
+        },
+        {
+          "type": "verse",
+          "number": 12,
+          "text": "o/ sɔ́ŋ mẁn tì/ ŋòot yẁm o/ pẁp tok, ò̬o̬ yẁm o/ kóoy kùu cẁw. o/ ác rèen sɔ́ŋ lə̀əŋ i/ rɛ̀ɛk tì/ lɔ̀k pʰéem póˑ kùu cẁw tì/ àn kẃwt yàav. o/ ác rèen sɔ́ŋ yẁm o/ ác kóoy mɛ̀h pẃ/ poo/, póˑ yẁm o/ okóoy mɛ̀h pẃ/ poo/. o/ ác rèen sɔ́ŋ kàh tì/ lɔ̀k pʰéem, yẁm o/ ác kóoy mɛ̀h kùu cẁw tɔ́ŋ.ác tì/ o/ só/ ɛ́h, póˑ yẁm o/ okóoy mɛ̀h tì/ o/ só/ ɛ́h."
+        },
+        {
+          "type": "verse",
+          "number": 13,
+          "text": "o/ plɔ́/ mɛ̀h pèen kùu cẁw tɔ́ŋ.ác tìˑ ntè/ pʰra/ kʰrístòo, ñò̬o̬n àn kàh o/ ɛ́h rɛ̀ɛŋ."
+        },
+        {
+          "type": "verse",
+          "number": 14,
+          "text": "tɛ̀ɛ àn lɔ̀k tì/ pɛ́ɛ/ cò̬o̬y o/ yẁm o/ tò̬o̬ŋ káan cò̬o̬y."
+        },
+        {
+          "type": "verse",
+          "number": 15,
+          "text": "hi/i/ pɛ́ɛ/ tì/ ntè/ mə̀əŋ pʰilippooy. pɛ́ɛ/ cẃw yẁm o/ kɔ́ɔ/ rɛ̀ɛk tì/ prán sɔ́ɔn lə̀əŋ kʰáav lɔ̀k kʰáav bɔ́h tìˑ nɛ̀h. yẁm o/ lèh píc kʰvɛ́ɛŋ màkèedóonia, mɛ̀h nẁm hi/i/ vàt pɛ́ɛ/ tì/ cò̬o̬y o/."
+        },
+        {
+          "type": "verse",
+          "number": 16,
+          "text": "àn kóoy báaŋ ràav pɛ́ɛ/ tóol kʰɔ́ŋ tì/ o/ tò̬o̬ŋ káan, yẁm o/ ŋòot tìˑ ntè/ mə̀əŋ tʰèesáʼlòonik."
+        },
+        {
+          "type": "verse",
+          "number": 17,
+          "text": "àn mɛ̀h ñìh. àn kóˑ mɛ̀h o/ só/ ràb kʰɔ́ŋ tì/ tòh píc pɛ́ɛ/. tɛ̀ɛ o/ só/ kàh pɛ́ɛ/ kóoy kʰɔ́ŋ lɔ̀k tì/ tòh píc i/ tii kàh."
+        },
+        {
+          "type": "verse",
+          "number": 18,
+          "text": "pwl/ə̀h o/ kóoy màak kùu cẁw, o/ kóoy tɔ́ŋ.ác tì/ o/ tò̬o̬ŋ káan, ñò̬o̬n èe/pafòdìtòo otòh kʰɔ́ŋ kèe/ anɛ̀h tìˑ o/. kʰɔ́ŋ tì/ pɛ́ɛ/ kàh anɛ̀h, àn mɛ̀h cá/ kʰɔ́ŋ múa, kʰɔ́ŋ tʼŋàaŋ. àn mɛ̀h kʰɔ́ŋ tàan tì/ pʰra/pincáv poo pʰéem tì/ ràb."
+        },
+        {
+          "type": "verse",
+          "number": 19,
+          "text": "pʰra/pincáv o/. àn cìi próot cày li/kùun tìˑ ntè/ pʰra/yesúu kʰrístòo. kàh kùu cẁw tì/ pɛ́ɛ/ tò̬o̬ŋ káan só/ ɛ́h."
+        },
+        {
+          "type": "verse",
+          "number": 20,
+          "text": "rɔ́ɔ tì/ kàh kìat kàh ñòt tìˑ pʰra/pincáv ùuñ ɛ̀/ tẁw tẁw, aa/mɛ̀ɛn."
+        },
+        {
+          "type": "verse",
+          "number": 21,
+          "text": "rɔ́ɔ kàh kùn.kò̬o̬ŋ lɔ̀k kʰɔ̀ŋ pʰra/pincáv ŋòot tìˑ hi/i/ pʰra/ kʰrístòo kùu i/. hi/i/ pʰa/cáv kèe/ anɔ̀h mɔ̀/ tì/ ŋòot póˑ o/ kèe/ rəpé/ rəlò̬/ ràk tòh tìˑ pɛ́ɛ/."
+        },
+        {
+          "type": "verse",
+          "number": 22,
+          "text": "hi/i/ pʰa/cáv tɔ́ŋ.ác kèe/ rəpé/ rəlò̬/ ràk tʰrikẁt tòh tìˑ pɛ́ɛ/, póˑ kèe/ tì/ kóoy pʰéem tẁwm tòh píc bɔ́ɔn kàaysa/ ŋòot. kèe/ rɔ́ɔ/ tì/ rəpé/ rəlò̬/ ràk rəlò̬/ /yám nàp.tʰẃw tòh tìˑ pɛ́ɛ/ dɛ́ɛ."
+        },
+        {
+          "type": "verse",
+          "number": 23,
+          "text": "rɔ́ɔ kàh kùn.kò̬o̬ŋ lɔ̀k tì/ tòh píc pʰra/yesúu kʰrístòo, ŋòot póˑ pɛ́ɛ/ tɔ́ŋ.ác kùu i/ nəə/."
+        }
+      ]
+    }
+  ]
+
+
+

--- a/samples/50PHP.json
+++ b/samples/50PHP.json
@@ -1,4 +1,185 @@
-  [
+{
+  "header": {
+      "projectName": "slt",
+      "bookInfo": {
+      "code": "PHP",
+      "name": "Philippians",
+      "num": 56,
+      "chapters": 4,
+      "verses": 104
+      }
+  },
+  "content": [
+    {
+      "type": "padding",
+      "number": 0
+    },
+    {
+      "type": "chapter",
+      "number": 1,
+      "content": [
+        {
+          "type": "verse",
+          "number": 1,
+          "text": "anɔ̀h mɛ̀h nàŋsẃw tòh píc polòo, póˑ timòtʰèev, kɔ́ɔn tiké/ pʰra/yesúu kʰrístòo. kʰyɛ̀ɛn kàh tìˑ hi/i/ saksít kʰɔ̀ŋ pʰra/yesúu kʰrístòo, mɔ̀/ tì/ ŋòot tìˑ ntè/ mə̀əŋ pʰilippooy, póˑ tìˑ hi/i/ kẃn kèe/ tì/ sicə́y raksáa pʰa/cáv."
+        },
+        {
+          "type": "verse",
+          "number": 2,
+          "text": "rɔ́ɔ kàh kùn.kò̬o̬ŋ lɔ̀k tì/ tòh píc pʰra/pincáv, póˑ pʰra/yesúu kʰrístòo ŋòot póˑ pɛ́ɛ/ tɔ́ŋ.ác kùu i/."
+        },
+        {
+          "type": "section",
+          "number": 1,
+          "text": "rəlò̬/ polòo súat rɔ́ɔ."
+        },
+        {
+          "type": "verse",
+          "number": 3,
+          "text": "kùu ràav o/ tʰrikẁt tòh tìˑ pɛ́ɛ/, o/ lɔ̀k pʰéem tìˑ pʰra/pincáv."
+        },
+        {
+          "type": "verse",
+          "number": 4,
+          "text": "o/ lɔ̀k pʰéem tì/ súat tẁw samlàp pɛ́ɛ/ tɔ́ŋ.ác."
+        },
+        {
+          "type": "verse",
+          "number": 5,
+          "text": "o/ lɔ̀k pʰéem tìˑ pʰra/pincáv samlàp vèek tì/ pɛ́ɛ/ ác cò̬o̬y o/, yẁm o/ prán sɔ́ɔn kʰáav lɔ̀k kʰáav bɔ́h. pɛ́ɛ/ rɛ̀ɛk tì/ cò̬o̬y o/ táŋ píc pɛ́ɛ/ kóoy rəlò̬/ tẁwm cò̬n tòh pwl/ə̀h."
+        },
+        {
+          "type": "verse",
+          "number": 6,
+          "text": "pʰra/pincáv rɛ̀ɛk tì/ plɔ́/ lɔ̀k tìˑ ntè/ pɛ́ɛ/. o/ nɛ́ɛ/ ñìh lɔ̀ɔ, àn cìi plɔ́/ kàh àn hóoc cò̬n siŋì/ pʰra/yesúu kʰrístòo tòh."
+        },
+        {
+          "type": "verse",
+          "number": 7,
+          "text": "o/ sɔ́ŋ lɔ̀ɔ, o/ tʰrikẁt lə̀əŋ anɔ̀h àn mɛ̀ɛn samlàp pɛ́ɛ/ tɔ́ŋ.ác. o/ nɛ́ɛ/ ñìh ñò̬o̬n o/ ràk pɛ́ɛ/ tìˑ ntè/ pʰéem o/. pɛ́ɛ/ bɛ́ɛŋ pán kùn.kò̬o̬ŋ lɔ̀k kʰɔ̀ŋ pʰra/pincáv póˑ o/ tɔ́ŋ.ác kùu i/. yẁm o/ ŋòot tìˑ ntè/ kʰùk, yẁm o/ swráaŋ tì/ lɔ̀ɔ rəlò̬/ plèh kàh àn mɛ̀h ñìh lə̀əŋ kʰáav lɔ̀k kʰáav bɔ́h. pʰra/pincáv àn sɔ́ŋ, lɔ̀ɔ, o/ càat.mɛ̀ɛ só/ tàm pɛ́ɛ/ màak. o/ ràk pɛ́ɛ/ tɔ́ŋ.ác póˑ rəlò̬/ ràk pʰra/yesúu kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 8,
+          "text": "pʰra/pincáv àn sɔ́ŋ, lɔ̀ɔ, o/ càat.mɛ̀ɛ só/ tàm pɛ́ɛ/ màak. o/ ràk pɛ́ɛ/ tɔ́ŋ.ác póˑ rəlò̬/ ràk pʰra/yesúu kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 9,
+          "text": "anɔ̀h mɛ̀h rəlò̬/ o/ súat rɔ́ɔ samlàp pɛ́ɛ/, kàh pɛ́ɛ/ kóoy rəlò̬/ ràk màak rɛ̀h tʰɛ́ɛm, kàh pɛ́ɛ/ kóoy kamkẁt panñàa sɔ́ŋ póˑ rəlò̬/ ràk anɛ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 10,
+          "text": "pɛ́ɛ/ cìi tàm àn táaŋ tʰrinà/ lɔ̀k póˑ kóˑ lɔ̀k, kàh pɛ́ɛ/ lə̀ək tì/ ɛ́h àn tì/ lɔ̀k, kàh pɛ́ɛ/ mɛ̀h hi/i/ lɔ̀k, cɛ́ɛŋ cəəs, okóoy mɛ̀h pʰít, yẁm pʰra/yesúu cìi cùa tòh tʰɛ́ɛm."
+        },
+        {
+          "type": "verse",
+          "number": 11,
+          "text": "pɛ́ɛ/ cìi plɔ́/ síiŋ tì/ lɔ̀k màak cẁw póˑ pʰra/yesúu tìˑ nɛ̀h, àn tì/ cò̬o̬y pɛ́ɛ/. kàh pɛ́ɛ/ otòh kìat otòh ñòt tìˑ pʰra/pincáv."
+        },
+        {
+          "type": "verse",
+          "number": 12,
+          "text": "polòo lɔ̀ɔ, yò/ ɛ̀ɛk ə̀əy, o/ só/ kàh pɛ́ɛ/ sɔ́ŋ, lɔ̀ɔ, àn ác kẃwt mɛ̀h yàav mɛ̀h tìˑ o/. àn mɛ̀h o/ tì/ ác cɛ́ɛk /yáay kʰáav lɔ̀k kʰáav bɔ́h anɔ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 13,
+          "text": "pwl/ə̀h o/ ŋòot tìˑ ntè/ kʰùk, ñò̬o̬n o/ tẁwm pʰra/ kʰrístòo. kùu bɔ́ɔn tɔ̀ŋ i/ kùm tɔ̀ŋ i/ ráŋ hi/i/. kùu i/ mɔ̀/ kò̬o̬ sɔ́ŋ lə̀əŋ anɔ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 14,
+          "text": "o/ nɔ́ɔŋ ŋòot tìˑ ntè/ kʰùk, tɛ̀ɛ samlàp i/ tì/ kóoy pʰéem tẁwm. pwl/ə̀h màak i/ àm lɔ̀k tì/. kèe/ kóoy pʰéem káa/ tì/ lɔ̀ɔ kʰáav lɔ̀k kʰáav bɔ́h lə̀əŋ pʰra/ kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 15,
+          "text": "àn mɛ̀h ñìh, kóoy báaŋ i/ kèe/ prán sɔ́ɔn lə̀əŋ pʰra/ kʰrístòo, ñò̬o̬n kèe/ crikè/ rwŋkàal pò̬/.tì/. tɛ̀ɛ báaŋ i/ kèe/ prán sɔ́ɔn lə̀əŋ pʰra/ kʰrístòo, ñò̬o̬n kèe/ só/ cò̬o̬y."
+        },
+        {
+          "type": "verse",
+          "number": 16,
+          "text": "kèe/ prán sɔ́ɔn ñò̬o̬n kèe/ kóoy pʰéem ràk, kèe/ sɔ́ŋ lɔ̀ɔ àn mɛ̀h pʰra/pincáv tì/ kàh o/ plɔ́/ vèek swráaŋ kinà/ kʰáav lɔ̀k kʰáav bɔ́h anɔ̀h."
+        },
+        {
+          "type": "verse",
+          "number": 17,
+          "text": "tɛ̀ɛ hi/i/ i/ kipò̬/ kèe/ prán sɔ́ɔn lə̀əŋ pʰra/ kʰrístòo, ñò̬o̬n kèe/ mɛ̀h hi/i/ rimɛ̀ɛm. samlàp vèek kèe/ prán sɔ́ɔn anɛ̀h àn pʰít. kèe/ só/ plɔ́/ banháa samlàp o/ tì/ ŋòot ntè/ kʰùk."
+        },
+        {
+          "type": "verse",
+          "number": 18,
+          "text": "tɛ̀ɛ tʰáa làmlay mɔ́ɔ kèe/ plɔ́/ banháa samlàp o/. síiŋ tì/ samkʰán anɛ̀h, àn mɛ̀h kèe/ prán sɔ́ɔn lə̀əŋ pʰra/ kʰrístòo. kèe/ kʰùan tì/ plɔ́/ kàh àn mɛ̀ɛn. tɛ̀ɛ mɔ́ɔ kèe/ kíi plɔ́/ àn pʰít mɔ̀/, o/ kò̬o̬ kláay lɔ̀k pʰéem. kàh pɛ́ɛ/ súat samlàp o/, kàh kwlpò/ pʰra/yesúu cò̬o̬y o/. o/ sɔ́ŋ lɔ̀ɔ banháa anɔ̀h àn otòh kàh i/ cò̬o̬y pənpò̬n o/."
+        },
+        {
+          "type": "verse",
+          "number": 19,
+          "text": "kàh pɛ́ɛ/ súat samlàp o/, kàh kwlpò/ pʰra/yesúu cò̬o̬y o/. o/ sɔ́ŋ lɔ̀ɔ banháa anɔ̀h àn otòh kàh i/ cò̬o̬y pənpò̬n o/."
+        },
+        {
+          "type": "verse",
+          "number": 20,
+          "text": "síiŋ tì/ o/ só/ ɛ́h póˑ síiŋ tì/ o/ vɔ́ŋ. anɛ̀h àn cìi kóˑ plɔ́/ kàh o/ looc, píc mɛ̀h mɔ̀/ tẃm mòh cẁw tìˑ ntè/ pʰra/ kʰrístòo. o/ vɔ́ŋ lɔ̀ɔ o/ kóoy pʰéem káa/ pwl/ə̀h, cá/ o/ kəəy kóoy, àn pléh pwnsó̬h kùn.kò̬o̬ŋ lɔ̀k samlàp pʰra/ kʰrístòo tìˑ còo o/ tìˑ ɔ̀h. tìˑ ntè/ lòok anɔ̀h o/ cìi yàm ò̬o̬ ìim, anɛ̀h àn mɛ̀h vèek tì/ o/ só/ plɔ́/. síiŋ tì/ samkʰán tìˑ o/ tisʊ́t lə̀əŋ kóoy còo ìim àn mɛ̀h pʰra/ kʰrístòo. kíi.mɛ̀h nẁm rəmyàm mɔ̀/, àn kò̬o̬ kóoy pəñòot samlàp o/."
+        },
+        {
+          "type": "verse",
+          "number": 21,
+          "text": "síiŋ tì/ samkʰán tìˑ o/ tisʊ́t lə̀əŋ kóoy còo ìim àn mɛ̀h pʰra/ kʰrístòo. kíi.mɛ̀h nẁm rəmyàm mɔ̀/, àn kò̬o̬ kóoy pəñòot samlàp o/."
+        },
+        {
+          "type": "verse",
+          "number": 22,
+          "text": "mɔ́ɔ o/ nɔ́ɔŋ kóoy còo ìim, tóo o/ kò̬o̬ samàat tì/ plɔ́/ vèek pʰa/cáv. tɛ̀ɛ o/ cìi lə̀ək ti/ ɛ́h amɔ̀/, yàm ò̬o̬ ìimʔ o/ kóˑ sɔ́ŋ."
+        },
+        {
+          "type": "verse",
+          "number": 23,
+          "text": "tʰrinà/ anɔ̀h li/àa cẁw, i/ lə̀ək àn càat.mɛ̀ɛ yàak. o/ só/ hó̬k píc còo anɔ̀h vɔ̀k ŋòot póˑ pʰra/ kʰrístòo, anɛ̀h àn lɔ̀k màak lə́ə i/."
+        },
+        {
+          "type": "verse",
+          "number": 24,
+          "text": "tɛ̀ɛ pɛ́ɛ/ tò̬o̬ŋ káan o/ tìˑ ɔ̀h, tìˑ ntè/ tóo o/, o/ sɔ́ŋ lɔ̀ɔ pɛ́ɛ/ tò̬o̬ŋ káan o/."
+        },
+        {
+          "type": "verse",
+          "number": 25,
+          "text": "o/ sɔ́ŋ lɔ̀ɔ o/ ŋòot póˑ pɛ́ɛ/. o/ cìi cò̬o̬y kàh pɛ́ɛ/ prɛ̀ɛ/ rɛ̀h màak, kàh pɛ́ɛ/ sə́əs sə́əl, kóoy rəlò̬/ tẁwm."
+        },
+        {
+          "type": "verse",
+          "number": 26,
+          "text": "pɛ́ɛ/ cìi càat.mɛ̀ɛ lɔ̀k pʰéem tìˑ ntè/ pʰra/yesúu kʰrístòo, yẁm o/ cìi tòh ŋòot póˑ pɛ́ɛ/ tʰɛ́ɛm."
+        },
+        {
+          "type": "verse",
+          "number": 27,
+          "text": "tɛ̀ɛ rɔ́ɔ kàh àn nɛ́ɛnò̬o̬n, lɔ̀ɔ, pɛ́ɛ/ ŋòot lɔ̀ŋ àn trɔ́/ lɔ̀ŋ án cɛ̀ɛp, tìˑ kʰáav lɔ̀k kʰáav bɔ́h kʰɔ̀ŋ pʰra/ kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 27,
+          "text": "yẁm o/ tòh ɛ̀ɛv pɛ́ɛ/, ò̬o̬ yẁm o/ ŋòot səŋáay kò̬o̬ càaŋ, o/ cìi àm síiŋ tì/ lɔ̀k samlàp pɛ́ɛ/. anɛ̀h o/ cìi sɔ́ŋ lɔ̀ɔ, pɛ́ɛ/ nɔ́ɔŋ mɛ̀h mòh i/ mòh pʰéem, rùum pò̬/.tì/ plɔ́/ vèek kàh àn mɛ̀h nẁm mòh pẁwŋ, tẁwm tùul póˑ pò̬/.tì/ tìˑ kʰáav bɔ́h. hóoc pɛ́ɛ/ cìi kóˑ láat hi/i/ kèe/ anɔ̀h mɔ̀/ tì/ to̬súu pɛ́ɛ/. síiŋ kèe/ anɔ̀h tɔ́ŋ.ác àn tòh píc pʰra/pincáv, anɛ̀h àn cìi cò̬o̬y pənpò̬n pɛ́ɛ/, sat.tùu pɛ́ɛ/ kèe/ cìi kàan kóˑ pɛ̀ɛv."
+        },
+        {
+          "type": "verse",
+          "number": 28,
+          "text": "hóoc pɛ́ɛ/ cìi kóˑ láat hi/i/ kèe/ anɔ̀h mɔ̀/ tì/ to̬súu pɛ́ɛ/. síiŋ kèe/ anɔ̀h tɔ́ŋ.ác àn tòh píc pʰra/pincáv, anɛ̀h àn cìi cò̬o̬y pənpò̬n pɛ́ɛ/, sat.tùu pɛ́ɛ/ kèe/ cìi kàan kóˑ pɛ̀ɛv."
+        },
+        {
+          "type": "verse",
+          "number": 29,
+          "text": "pʰra/pincáv kàh anɔ̀h tìˑ pɛ́ɛ/ tɔ́ŋ li/àa, tìˑ ntè/ pʰra/ kʰrístòo. rəlò̬/ tẁwm póˑ rəlò̬/ tòk təəl samlàp pʰra/ kʰrístòo. síiŋ kàa anɔ̀h tɔ́ŋ li/àa, àn otòh kìat otòh ñòt tìˑ pʰra/ kʰrístòo."
+        },
+        {
+          "type": "verse",
+          "number": 30,
+          "text": "yẁm o/ ŋòot póˑ pɛ́ɛ/, pɛ́ɛ/ tàm tòk mɛ̀h tì/ o/ kóoy. pwl/ə̀h pɛ́ɛ/ àm lə̀əŋ tòk tì/ o/ kóoy. pɛ́ɛ/ póˑ kèe/ tì/ mɛ̀h kʰɔ́ɔy pẁp tòk simə̀ə pò̬/.tì/."
+        }
+      ]
+    },
     {
       "type": "chapter",
       "number": 2,
@@ -413,6 +594,4 @@
       ]
     }
   ]
-
-
-
+}

--- a/samples/50PHP.json
+++ b/samples/50PHP.json
@@ -4,7 +4,7 @@
       "bookInfo": {
       "code": "PHP",
       "name": "Philippians",
-      "num": 56,
+      "num": 50,
       "chapters": 4,
       "verses": 104
       }
@@ -348,7 +348,7 @@
     },
     {
       "type": "chapter",
-      "numnber": 3,
+      "number": 3,
       "content": [
         {
           "type": "section",

--- a/samples/56TIT.json
+++ b/samples/56TIT.json
@@ -1,6 +1,6 @@
 ﻿{
   "header": {
-    "projectName": "Sample",
+    "projectName": "slt",
     "bookInfo": {
       "code": "TIT",
       "name": "Titus",
@@ -45,7 +45,7 @@
         },
         {
           "type": "section",
-          "number": 2,
+          "number": 1,
           "text": "lə̀əŋ titòo plɔ́/ vèek ŋòot tìi kɔ́/ káʼrètèe/."
         },
         {

--- a/samples/56TIT.json
+++ b/samples/56TIT.json
@@ -21,7 +21,7 @@
         {
           "type": "section",
           "number": 1,
-          "text": "anɔ̀h mɛ̀h naŋsẃw polòo kʰyɛ̀ɛn tóot tìi titòo"
+          "text": "anɔ̀h mɛ̀h naŋsẃw polòo kʰyɛ̀ɛn tóot tìi titòo."
         },
         {
           "type": "verse",
@@ -109,6 +109,14 @@
           "text": "kèe/ lɔ̀ɔ kèe/ sɔ́ŋ pʰra/pincáv, tɛ̀ɛ lə̀əŋ súuə tì/ kèe/ plɔ́/ àn pléh kàh i/ tàm lɔ̀ɔ, kèe/ kóo ràp pʰra/pincáv. kèe/ mɛ̀h hi/i/ mpít hi/i/ báap, kèe/ kóo ñoom tì/ /yám nàp.tʰẃw síŋ tì/ kèe/ plɔ́/ lɔ̀k, i/ cày kèe/ kóo pèen."
         }
       ]
+    },
+    {
+      "type": "padding",
+      "number": 2
+    },
+    {
+      "type": "padding",
+      "number": 3
     }
   ]
 }

--- a/src/books.ts
+++ b/src/books.ts
@@ -589,7 +589,7 @@ export class Books {
         break;
       case 'I Corinthians':
       case '1Corinthians':
-        bookName = '1 Corinthians';
+        bookName = "1 Corinthians";
         break;
       case '2Corinthians':
         bookName = '2 Corinthians';
@@ -618,10 +618,11 @@ export class Books {
       default:
         bookName = name;
     }
-    const book : bookType = bookInfo.find(b => b.name === bookName) as bookType;
+    let book : bookType = bookInfo.find(b => b.name === bookName) as bookType;
     if (book === undefined) {
       console.error(`Spreadsheet may have a typo for book name: ${name}. Exiting`);
-      process.exit(1);
+      book = bookInfo[0];
+      //process.exit(1);
     }
     return book;
   }

--- a/src/books.ts
+++ b/src/books.ts
@@ -564,7 +564,7 @@ export function getBookByCode(bookCode: CodeType): bookType {
 export function getBookByName(name: string): bookType {
   let bookName: string;
   // Override typos/alternate spellings in book name
-  // TODO: are xNames to be ignored?
+  // TODO: are aNames or xNames to be ignored?
   switch(name) {
     // OT
     case 'Dueteronomy':

--- a/src/books.ts
+++ b/src/books.ts
@@ -542,6 +542,12 @@ export class Books {
       case 'Dueteronomy':
         bookName = 'Deuteronomy';
         break;
+      case '1 Samual':
+        bookName = '1 Samuel';
+        break;
+      case '2 Samual':
+        bookName = '2 Samuel';
+        break;
       case 'Song of Solomon':
         bookName = 'Song of Songs';
         break;

--- a/src/books.ts
+++ b/src/books.ts
@@ -554,23 +554,66 @@ export class Books {
     let bookName: string;
     // Override P&P typos/alternate spellings in book name
     switch(name) {
+      // OT
       case 'Dueteronomy':
         bookName = 'Deuteronomy';
         break;
-      case '1 Samual':
+      case '1Samuel':
         bookName = '1 Samuel';
         break;
-      case '2 Samual':
+      case '2Samuel':
         bookName = '2 Samuel';
+        break;
+      case '1Kings':
+        bookName = '1 Kings';
+        break;
+      case '2Kings':
+        bookName = '2 Kings';
         break;
       case 'Song of Solomon':
         bookName = 'Song of Songs';
         break;
+      case 'jonah':
+        bookName = 'Jonah';
+        break;
       case 'Zachariah':
         bookName = 'Zechariah';
         break;
+
+      // NT
+      case 'aMatthew':
+        bookName = 'Matthew';
+        break;
+      case 'aLuke':
+        bookName = 'Luke';
+        break;
       case 'I Corinthians':
-        bookName = "1 Corinthians";
+      case '1Corinthians':
+        bookName = '1 Corinthians';
+        break;
+      case '2Corinthians':
+        bookName = '2 Corinthians';
+        break;
+      case '1Thessalonians':
+        bookName = '1 Thessalonians';
+        break;
+      case '2Thessalonians':
+        bookName = '2 Thessalonians';
+        break;
+      case '1Timothy':
+        bookName = '1 Timothy';
+        break;
+      case '2Timothy':
+        bookName = '2 Timothy';
+        break;
+      case '1Peter':
+        bookName = '1 Peter';
+        break;
+      case '2Peter':
+        bookName = '2 Peter';
+        break;
+      case '1John':
+        bookName = '1 John';
         break;
       default:
         bookName = name;

--- a/src/books.ts
+++ b/src/books.ts
@@ -35,9 +35,12 @@ export interface bookType {
   verses: number;   // Total number of verses in the book
 }
 
-const bookInfo: bookType[] =
-[
-  {
+//#region bookInfo: bookType[]
+/**
+ * Array of bookType containing information about each book
+*/
+export const bookInfo: bookType[] = [
+{
     // Just a placeholder. Not a valid book
     code: "000",
     name: "Placeholder",
@@ -512,6 +515,7 @@ const bookInfo: bookType[] =
     verses: 404
   }
 ];
+//#endregion
 
 export interface unitType {
   type: string,
@@ -528,117 +532,124 @@ export interface objType {
   content: unitType[]
 }
 
-export class Books {
+export const PLACEHOLDER_BOOK: bookType = bookInfo[0];
+export const PLACEHOLDER_BOOK_OBJ: objType = {
+  "header": {
+    "projectName" : "",
+    "bookInfo" : PLACEHOLDER_BOOK
+  },
+  "content": []
+}
 
 /**
    * Get the book information given the 3-character book code
    * @param {CodeType} bookCode
    * @returns {bookType}
    */
-  public getBookByCode(bookCode: CodeType): bookType {
-    const book : bookType = bookInfo.find(b => b.code === bookCode) as bookType;
-    if (book === undefined) {
-      console.error(`getBookByCode() failed for book code: ${bookCode}`);
-      process.exit(1);
-    }
-    return book;
+export function getBookByCode(bookCode: CodeType): bookType {
+  const book : bookType = bookInfo.find(b => b.code === bookCode) as bookType;
+  if (book === undefined) {
+    console.error(`getBookByCode() failed for book code: ${bookCode}`);
+    process.exit(1);
   }
-
-  /**
-   * Get the book information given the book name.
-   * Also handles P&P typos / alternate spellings in book name
-   * @param {string} name
-   * @returns {bookType}
-   */
-  public getBookByName(name: string): bookType {
-    let bookName: string;
-    // Override P&P typos/alternate spellings in book name
-    switch(name) {
-      // OT
-      case 'Dueteronomy':
-        bookName = 'Deuteronomy';
-        break;
-      case '1Samuel':
-        bookName = '1 Samuel';
-        break;
-      case '2Samuel':
-        bookName = '2 Samuel';
-        break;
-      case '1Kings':
-        bookName = '1 Kings';
-        break;
-      case '2Kings':
-        bookName = '2 Kings';
-        break;
-      case 'Song of Solomon':
-        bookName = 'Song of Songs';
-        break;
-      case 'jonah':
-        bookName = 'Jonah';
-        break;
-      case 'Zachariah':
-        bookName = 'Zechariah';
-        break;
-
-      // NT
-      case 'aMatthew':
-        bookName = 'Matthew';
-        break;
-      case 'aLuke':
-        bookName = 'Luke';
-        break;
-      case 'I Corinthians':
-      case '1Corinthians':
-        bookName = "1 Corinthians";
-        break;
-      case '2Corinthians':
-        bookName = '2 Corinthians';
-        break;
-      case '1Thessalonians':
-        bookName = '1 Thessalonians';
-        break;
-      case '2Thessalonians':
-        bookName = '2 Thessalonians';
-        break;
-      case '1Timothy':
-        bookName = '1 Timothy';
-        break;
-      case '2Timothy':
-        bookName = '2 Timothy';
-        break;
-      case '1Peter':
-        bookName = '1 Peter';
-        break;
-      case '2Peter':
-        bookName = '2 Peter';
-        break;
-      case '1John':
-        bookName = '1 John';
-        break;
-      default:
-        bookName = name;
-    }
-    let book : bookType = bookInfo.find(b => b.name === bookName) as bookType;
-    if (book === undefined) {
-      console.error(`Spreadsheet may have a typo for book name: ${name}. Exiting`);
-      book = bookInfo[0];
-      //process.exit(1);
-    }
-    return book;
-  }
-
-  /**
-   * Get the book information given the book number.
-   * If an invalid book number given, return the placeholder
-   * @param {number} bookNumber
-   * @returns {bookType}
-   */
-  public getBookByNumber(bookNumber: number) : bookType {
-    if (bookNumber < 1 || bookNumber > 66) {
-      console.error(`getBookByNumber failed with book number: ${bookNumber}`);
-      process.exit(1);
-    }
-
-    return bookInfo[bookNumber];
-  }
+  return book;
 }
+
+/**
+ * Get the book information given the book name.
+ * Also handles typos / alternate spellings in book name
+ * @param {string} name
+ * @returns {bookType}
+ */
+export function getBookByName(name: string): bookType {
+  let bookName: string;
+  // Override typos/alternate spellings in book name
+  // TODO: are xNames to be ignored?
+  switch(name) {
+    // OT
+    case 'Dueteronomy':
+      bookName = 'Deuteronomy';
+      break;
+    case '1Samuel':
+      bookName = '1 Samuel';
+      break;
+    case '2Samuel':
+      bookName = '2 Samuel';
+      break;
+    case '1Kings':
+      bookName = '1 Kings';
+      break;
+    case '2Kings':
+      bookName = '2 Kings';
+      break;
+    case 'Song of Solomon':
+      bookName = 'Song of Songs';
+      break;
+    case 'jonah':
+      bookName = 'Jonah';
+      break;
+    case 'Zachariah':
+      bookName = 'Zechariah';
+      break;
+
+    // NT
+    case 'aMatthew':
+      bookName = 'Matthew';
+      break;
+    case 'aLuke':
+      bookName = 'Luke';
+      break;
+    case 'I Corinthians':
+    case '1Corinthians':
+    case 'x1Corinthians':
+      bookName = "1 Corinthians";
+      break;
+    case '2Corinthians':
+      bookName = '2 Corinthians';
+      break;
+    case '1Thessalonians':
+      bookName = '1 Thessalonians';
+      break;
+    case '2Thessalonians':
+      bookName = '2 Thessalonians';
+      break;
+    case '1Timothy':
+      bookName = '1 Timothy';
+      break;
+    case '2Timothy':
+      bookName = '2 Timothy';
+      break;
+    case '1Peter':
+      bookName = '1 Peter';
+      break;
+    case '2Peter':
+      bookName = '2 Peter';
+      break;
+    case '1John':
+      bookName = '1 John';
+      break;
+    default:
+      bookName = name;
+  }
+  let book : bookType = bookInfo.find(b => b.name === bookName) as bookType;
+  if (book === undefined) {
+    console.warn(`WARNING: possible typo for book name: ${name}. Returning placeholder`);
+    book = PLACEHOLDER_BOOK;
+  }
+  return book;
+}
+
+/**
+ * Get the book information given the book number (between 1 and 66 inclusive).
+ * @param {number} bookNumber
+ * @returns {bookType}
+ */
+export function getBookByNumber(bookNumber: number) : bookType {
+  if (bookNumber < 1 || bookNumber > 66) {
+    console.error(`getBookByNumber failed with book number: ${bookNumber}`);
+    process.exit(1);
+  }
+
+  return bookInfo[bookNumber];
+}
+

--- a/src/books.ts
+++ b/src/books.ts
@@ -513,6 +513,21 @@ const bookInfo: bookType[] =
   }
 ];
 
+export interface unitType {
+  type: string,
+  number: number,
+  content?: any,
+  text?: string
+}
+
+export interface objType {
+  header: {
+    projectName: string,
+    bookInfo:  bookType
+  },
+  content: unitType[]
+}
+
 export class Books {
 
 /**

--- a/src/books.ts
+++ b/src/books.ts
@@ -558,8 +558,8 @@ export function getBookByCode(bookCode: CodeType): bookType {
 /**
  * Get the book information given the book name.
  * Also handles typos / alternate spellings in book name
- * @param {string} name
- * @returns {bookType}
+ * @param {string} name of the book
+ * @returns {bookType} Information about the book
  */
 export function getBookByName(name: string): bookType {
   let bookName: string;
@@ -599,6 +599,9 @@ export function getBookByName(name: string): bookType {
     case 'aLuke':
       bookName = 'Luke';
       break;
+    case 'aActs':
+      bookName = 'Acts';
+      break;
     case 'I Corinthians':
     case '1Corinthians':
     case 'x1Corinthians':
@@ -633,7 +636,7 @@ export function getBookByName(name: string): bookType {
   }
   let book : bookType = bookInfo.find(b => b.name === bookName) as bookType;
   if (book === undefined) {
-    console.warn(`WARNING: possible typo for book name: ${name}. Returning placeholder`);
+    console.warn(`Skipping book name: ${name}. Returning placeholder`);
     book = PLACEHOLDER_BOOK;
   }
   return book;

--- a/src/fileAssistant.ts
+++ b/src/fileAssistant.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as books from './books';
+
+
+/**
+ * Recursively push to an array all the txt file paths from inside a given directory
+ * @param { string } directory - a path to a directory to recurse through
+ * @param { string[] } fileArray - a string array to fill with the paths of txt files
+ */
+export function getTextFilesInside(directory: string, fileArray: string[]){
+  fs.readdirSync(directory).forEach(function(item){
+    const absolutePath = path.join(directory, item);
+    if (fs.statSync(absolutePath).isDirectory()){
+      return getTextFilesInside(absolutePath, fileArray);
+    }
+    else{
+      if(item.substring(item.lastIndexOf('.')+1, item.length) === 'txt'){
+        fileArray.push(absolutePath);
+      }
+      return;
+    }
+  });
+}
+
+
+/**
+ * Check the first level of a directory to find book directories
+ * @param { string } superDirectory - a path to a directory to search for book directories
+ */
+export function getBookDirectories(superDirectory: string, bookDirectoryArray: string[]){
+  fs.readdirSync(superDirectory).forEach(function(item) {
+    const absolutePath = path.join(superDirectory, item);
+    if (fs.statSync(absolutePath).isDirectory()) {
+      bookDirectoryArray.push(absolutePath);
+    }
+  })
+}
+
+

--- a/src/fileAssistant.ts
+++ b/src/fileAssistant.ts
@@ -1,7 +1,7 @@
+// Copyright 2022 SIL International
+// Utilites for handling file paths
 import * as fs from 'fs';
 import * as path from 'path';
-import * as books from './books';
-
 
 /**
  * Recursively push to an array all the txt file paths from inside a given directory
@@ -13,8 +13,7 @@ export function getTextFilesInside(directory: string, fileArray: string[]){
     const absolutePath = path.join(directory, item);
     if (fs.statSync(absolutePath).isDirectory()){
       return getTextFilesInside(absolutePath, fileArray);
-    }
-    else{
+    } else{
       if(item.substring(item.lastIndexOf('.')+1, item.length) === 'txt'){
         fileArray.push(absolutePath);
       }
@@ -22,7 +21,6 @@ export function getTextFilesInside(directory: string, fileArray: string[]){
     }
   });
 }
-
 
 /**
  * Check the first level of a directory to find book directories
@@ -36,5 +34,3 @@ export function getBookDirectories(superDirectory: string, bookDirectoryArray: s
     }
   })
 }
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,9 +131,12 @@ if (options.json) {
     toolbox.updateObj(bookObj, file, currentChapter);
   });
   // For testing, write out each book's JSON to file
-  fs.writeFileSync('./' + bookObj.header.bookInfo.num +
-    bookObj.header.bookInfo.code + bookObj.header.projectName + '.json', JSON.stringify(bookObj, null, 2));
-  console.info('Writing out book object');
+  if (bookObj.header.bookInfo.code !== "000") {
+    const padZero = bookObj.header.bookInfo.num < 10 ? '0': '';
+    fs.writeFileSync('./' + padZero + bookObj.header.bookInfo.num +
+      bookObj.header.bookInfo.code + bookObj.header.projectName + '.json', JSON.stringify(bookObj, null, 2));
+    console.info('Writing out book object');
+  }
 
 } else {
   console.warn("No input files provided. Exiting");
@@ -142,7 +145,7 @@ if (options.json) {
 
 
 
-// Write out the JSON Objects to SFM
-if (bookObj) {
+// Write out valid JSON Objects to SFM
+if (bookObj.header.bookInfo.code !== "000") {
   sfm.convertToSFM(bookObj);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ program
 
 // Debugging parameters
 const options = program.opts();
-const debugParameters = true;
-if (debugParameters) {
+const debugMode = true;
+if (debugMode) {
   console.log('Parameters:');
   if (options.text) {
     console.log(`Toolbox text file path: "${options.text}"`);
@@ -134,15 +134,12 @@ function processDirectory(directory: string){
     bookObj = processText(file, bookObj);
   });
 
-  // Write out valid JSON Object to SFM
+  // Directory processed, so write valid output
   if (bookObj.header.bookInfo.code !== "000") {
     // For testing, write out book JSON Object
-    const padZero = bookObj.header.bookInfo.num < 10 ? '0' : '';
-    fs.writeFileSync('./' + padZero + bookObj.header.bookInfo.num +
-      bookObj.header.bookInfo.code + bookObj.header.projectName + '.json',
-      JSON.stringify(bookObj, null, 2));
-    console.info('Writing out book object');
+    writeJSON(bookObj);
 
+    // valid JSON Object to SFM
     sfm.convertToSFM(bookObj);
   }
 }
@@ -174,14 +171,10 @@ function processText(filepath: string, bookObj: books.objType): books.objType {
 
     toolbox.updateObj(bookObj, filepath, currentChapter);
 
-    // For single file parameter, write output
+    // For single file parameter, write valid output
     if (options.text && bookObj.header.bookInfo.code !== "000") {
       // For testing, write out book JSON Object
-      const padZero = bookObj.header.bookInfo.num < 10 ? '0' : '';
-      fs.writeFileSync('./' + padZero + bookObj.header.bookInfo.num +
-        bookObj.header.bookInfo.code + bookObj.header.projectName + '.json',
-        JSON.stringify(bookObj, null, 2));
-      console.info('Writing out book object');
+      writeJSON(bookObj);
 
       //valid JSON Object to SFM
       sfm.convertToSFM(bookObj);
@@ -222,3 +215,22 @@ function processJSON(filepath: string){
 ////////////////////////////////////////////////////////////////////
 // End of processor functions
 ////////////////////////////////////////////////////////////////////
+
+/**
+ * Write JSON file (for testing purposes).
+ * Filename will be [##][XYZ][Project name].json
+ * ## - 2-digit book number
+ * XYZ - 3 character book code
+ * Project name - Paratext project name
+ * @param {books.bookType} bookObj - the book object to write to file
+ */
+function writeJSON(bookObj: books.objType) {
+  if (debugMode) {
+    // Add leading 0 if book number < 10
+    const padZero = bookObj.header.bookInfo.num < 10 ? '0' : '';
+    const filename = padZero + bookObj.header.bookInfo.num +
+      bookObj.header.bookInfo.code + bookObj.header.projectName + '.json';
+    fs.writeFileSync('./' + filename, JSON.stringify(bookObj, null, 2));
+    console.info(`Writing out "${filename}"`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,12 @@ if (options.superDirectory && !fs.existsSync(options.superDirectory)) {
   process.exit(1);
 }
 
+// Validate one of the optional parameters is given
+if (!options.text && !options.directories && !options.json && !options.superDirectory) {
+  console.error("Need to pass another optional parameter [-t -d -j or -s]");
+  process.exit(1);
+}
+
 ////////////////////////////////////////////////////////////////////
 // Routing commands to functions
 ////////////////////////////////////////////////////////////////////

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,12 +96,12 @@ if (bookObj) {
   const MAIN_TITLE_MARKER = "\\mt ";
   const CHAPTER_MARKER = "\\c ";
   const SECTION_MARKER = "\\s1 ";
+  const PARAGRAPH_MARKER = "\n\\p";
   const VERSE_MARKER = "\\v ";
   const CRLF = "\n";
 
   const chapters = bookObj['content'];
 
-  //let outputFileName = options.text + '.SFM';
   let SFMtext = "";
 
   SFMtext += ID_MARKER + bookObj['header']['bookInfo']['code'] + ' ' +  bookObj['header']['projectName'] + CRLF;
@@ -118,7 +118,7 @@ if (bookObj) {
       sectionsAndVerses.forEach(function(snippet) {
         switch(snippet['type']) {
           case "section":
-            SFMtext += SECTION_MARKER + snippet['text'] + CRLF;
+            SFMtext += SECTION_MARKER + snippet['text'] + PARAGRAPH_MARKER + CRLF;
             break;
           case "verse":
             SFMtext += VERSE_MARKER + snippet['number'] as string + ' ' + snippet['text'] + CRLF;
@@ -130,7 +130,9 @@ if (bookObj) {
     }
   });
 
-  // TODO: project name variable
-  fs.writeFileSync('./' + (options.json.replace(/^.*[\\/]/, '')).replace('.json', '.SFM') + "slt", SFMtext);
+  const bookNum = bookObj['header']['bookInfo']['num'];
+  const bookCode = bookObj['header']['bookInfo']['code'];
+  const projectName = bookObj['header']['projectName'];
+  fs.writeFileSync('./' + bookNum + bookCode + projectName + '.SFM', SFMtext);
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ if (options.json && !fs.existsSync(options.json)) {
   console.error("Can't open JSON file " + options.json);
   process.exit(1);
 }
-if (options.json && !fs.existsSync(options.superDirectory)) {
+if (options.superDirectory && !fs.existsSync(options.superDirectory)) {
   console.error("Can't open project directory " + options.superDirectory);
   process.exit(1);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,14 +79,7 @@ if (options.json) {
   processJSON(options.json);
 } else if (options.text) {
   // Parse a txt file into a JSON object
-  const b = new books.Books();
-  const bookObj: books.objType = {
-    "header": {
-      "projectName" : "",
-      "bookInfo" : b.getBookByCode("000")
-    },
-    "content": []
-  };
+  const bookObj: books.objType = books.PLACEHOLDER_BOOK_OBJ;
   processText(options.text, bookObj);
 } else if (options.directory) {
   // Convert the text files in a directory into an SFM book file
@@ -119,14 +112,7 @@ function processSuperDirectory(superDirectory: string){
  * @param {string} directory - path to directory containing text files
  */
 function processDirectory(directory: string){
-  const b = new books.Books();
-  let bookObj: books.objType = {
-    "header": {
-      "projectName" : "",
-      "bookInfo" : b.getBookByCode("000")
-    },
-    "content": []
-  };
+  let bookObj: books.objType = books.PLACEHOLDER_BOOK_OBJ;
   // Get all the text files in the directory and then process them
   const filesToParse: string[] = [];
   fileAssistant.getTextFilesInside(directory, filesToParse);
@@ -189,14 +175,7 @@ function processText(filepath: string, bookObj: books.objType): books.objType {
  * @param {string} filepath - file path of a single JSON file
  */
 function processJSON(filepath: string){
-  const b = new books.Books();
-  let bookObj: books.objType = {
-    "header": {
-      "projectName" : "",
-      "bookInfo" : b.getBookByCode("000")
-    },
-    "content": []
-  };
+  let bookObj: books.objType = books.PLACEHOLDER_BOOK_OBJ;
   try {
     bookObj = require(filepath);
   } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,10 @@ function processText(filepath: string) {
 
     toolbox.updateObj(bookObj, filepath, currentChapter);
 
+    // For single file parameter, write out valid JSON Object to SFM
+    if (options.text && bookObj.header.bookInfo.code !== "000") {
+      sfm.convertToSFM(bookObj);
+    }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as books from './books';
 import * as toolbox from './toolbox';
+import * as sfm from './sfm';
 const {version} = require('../package.json');
 
 ////////////////////////////////////////////////////////////////////
@@ -79,9 +80,26 @@ if (options.text) {
   // Parse a txt file into JSON Object
   filesToParse.push(options.text);
 } else if (options.directory) {
-// TODO: Handle options.directory to get list of all txt files to process and ignore certain directories
-
+  // Get a list of all txt files in options.directory and ignore certain directories
+  getTextFilesInside(options.directory, filesToParse);
 }
+
+// Recursively puts text files from a directory into an array
+function getTextFilesInside(directory, fileArray){
+  fs.readdirSync(directory).forEach(function(file){
+    const absolutePath = path.join(directory, file);
+    if (fs.statSync(absolutePath).isDirectory()){
+      return getTextFilesInside(absolutePath, fileArray);
+    }
+    else{
+      if(file.substring(file.lastIndexOf('.')+1, file.length) === 'txt'){
+        fileArray.push(absolutePath);
+      }
+      return;
+    }
+  });
+}
+
 
 if (options.json) {
   // Get the book status from the JSON file
@@ -106,53 +124,5 @@ if (options.json) {
 
 // Write out the JSON Objects to SFM
 if (bookObj) {
-
-  const ID_MARKER = "\\id ";
-  const USFM_MARKER = "\\usfm ";
-  const HEADER_MARKER = "\\h ";
-  const TOC_MARKER = "\\toc ";
-  const MAIN_TITLE_MARKER = "\\mt ";
-  const CHAPTER_MARKER = "\\c ";
-  const SECTION_MARKER = "\\s1 ";
-  const PARAGRAPH_MARKER = "\n\\p";
-  const VERSE_MARKER = "\\v ";
-  const CRLF = "\n";
-
-  const chapters = bookObj.content;
-
-  let SFMtext = "";
-
-  SFMtext += ID_MARKER + bookObj.header.bookInfo.code + ' ' +  bookObj.header.projectName + CRLF;
-  SFMtext += USFM_MARKER + '3.0' + CRLF;
-  SFMtext += HEADER_MARKER + bookObj.header.bookInfo.name + CRLF;
-  SFMtext += TOC_MARKER + bookObj.header.bookInfo.name + CRLF;
-  SFMtext += MAIN_TITLE_MARKER + bookObj.header.bookInfo.name + CRLF;
-
-
-  chapters.forEach(function(chapter) {
-    if(chapter.number != 0){
-      SFMtext += CHAPTER_MARKER + chapter.number + CRLF;
-      if(chapter.content){
-        const sectionsAndVerses = chapter.content;
-        sectionsAndVerses.forEach(function(unit) {
-          switch(unit.type) {
-            case "section":
-              SFMtext += SECTION_MARKER + unit.text + PARAGRAPH_MARKER + CRLF;
-              break;
-            case "verse":
-              SFMtext += VERSE_MARKER + unit.number + ' ' + unit.text + CRLF;
-              break;
-            default:
-              throw 'Invalid type on ' + JSON.stringify(unit) + '. \nLooking for "section" or "verse".';
-          }
-        });
-      }
-    }
-  });
-
-  const bookNum = bookObj.header.bookInfo.num;
-  const bookCode = bookObj.header.bookInfo.code;
-  const projectName = bookObj.header.projectName;
-  fs.writeFileSync('./' + bookNum + bookCode + projectName + '.SFM', SFMtext);
-
+  sfm.convertToSFM(bookObj);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ if (options.superDirectory && !fs.existsSync(options.superDirectory)) {
 }
 
 // Validate one of the optional parameters is given
-if (!options.text && !options.directories && !options.json && !options.superDirectory) {
+if (!options.text && !options.directory && !options.json && !options.superDirectory) {
   console.error("Need to pass another optional parameter [-t -d -j or -s]");
   process.exit(1);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ program
 
 // Debugging parameters
 const options = program.opts();
-const debugMode = true;
+const debugMode = false;
 if (debugMode) {
   console.log('Parameters:');
   if (options.text) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,15 +55,17 @@ if (options.json && !fs.existsSync(options.json)) {
 
 let bookObj = {};
 
-// TODO: Handle options.directory to get list of all txt files to process and ignore certain directories
+const filesToParse: string[] = [];
 
 if (options.text) {
   // Parse a txt file into JSON Object
-  bookObj = toolbox.parse(options.text, "slt");
+  filesToParse.push(options.text);
+} else if (options.directory) {
+// TODO: Handle options.directory to get list of all txt files to process and ignore certain directories
 
-  // For testing, write out each book's JSON to file
+}
 
-} else if (options.json) {
+if (options.json) {
   // Get the book status from the JSON file
   try {
     bookObj = require(options.json);
@@ -71,6 +73,12 @@ if (options.text) {
     console.error("Invalid JSON file. Exiting")
     process.exit(1);
   }
+} else if (filesToParse.length > 0) {
+  filesToParse.forEach(file => {
+    bookObj = toolbox.parse(file, "slt");
+  });
+  // For testing, write out each book's JSON to file
+
 } else {
   console.warn("No directory or JSON file given. Exiting");
   process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ function processSuperDirectory(superDirectory: string){
  */
 function processDirectory(directory: string){
   const b = new books.Books();
-  const bookObj: books.objType = {
+  let bookObj: books.objType = {
     "header": {
       "projectName" : "",
       "bookInfo" : b.getBookByCode("000")
@@ -131,11 +131,18 @@ function processDirectory(directory: string){
   const filesToParse: string[] = [];
   fileAssistant.getTextFilesInside(directory, filesToParse);
   filesToParse.forEach(file => {
-    processText(file, bookObj);
+    bookObj = processText(file, bookObj);
   });
 
   // Write out valid JSON Object to SFM
   if (bookObj.header.bookInfo.code !== "000") {
+    // For testing, write out book JSON Object
+    const padZero = bookObj.header.bookInfo.num < 10 ? '0' : '';
+    fs.writeFileSync('./' + padZero + bookObj.header.bookInfo.num +
+      bookObj.header.bookInfo.code + bookObj.header.projectName + '.json',
+      JSON.stringify(bookObj, null, 2));
+    console.info('Writing out book object');
+
     sfm.convertToSFM(bookObj);
   }
 }
@@ -144,12 +151,14 @@ function processDirectory(directory: string){
 /**
  * Take a text file and make a JSON book type object
  * @param {string} filepath - file path of a single text file
+ * @param {books.bookType} bookObj - the book object to modify
+ * @returns {books.bookType} bookObj - modified book object
  */
-function processText(filepath: string, bookObj: books.objType) {
+function processText(filepath: string, bookObj: books.objType): books.objType {
   const bookInfo = toolbox.getBookAndChapter(filepath);
     if (bookInfo.bookName === "Placeholder") {
       // Skip invalid files
-      return;
+      return bookObj;
     }
 
     if (bookObj.content.length == 0) {
@@ -165,10 +174,20 @@ function processText(filepath: string, bookObj: books.objType) {
 
     toolbox.updateObj(bookObj, filepath, currentChapter);
 
-    // For single file parameter, write out valid JSON Object to SFM
+    // For single file parameter, write output
     if (options.text && bookObj.header.bookInfo.code !== "000") {
+      // For testing, write out book JSON Object
+      const padZero = bookObj.header.bookInfo.num < 10 ? '0' : '';
+      fs.writeFileSync('./' + padZero + bookObj.header.bookInfo.num +
+        bookObj.header.bookInfo.code + bookObj.header.projectName + '.json',
+        JSON.stringify(bookObj, null, 2));
+      console.info('Writing out book object');
+
+      //valid JSON Object to SFM
       sfm.convertToSFM(bookObj);
     }
+
+    return bookObj;
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ program
     .option("-t, --text <path to single text file>", "path to a Toolbox text file")
     .option("-d, --directory <path to directory containing text files>", "path to directory containing multiple Toolbox text files")
     .option("-j, --json <jsonObject path>", "path to JSON Object file")
+    .option("-p, --projectName <name>", "name of the Paratext project>")
   .parse(process.argv);
 
 // Debugging parameters
@@ -33,7 +34,16 @@ if (debugParameters) {
   if (options.json) {
     console.log(`JSON file: "${options.json}"`);
   }
+  if (options.projectName) {
+    console.log(`Project Name: "${options.projectName}`);
+  }
   console.log('\n');
+}
+
+// Project Neme required
+if (!options.projectName) {
+  console.error("Project name required");
+  process.exit(1);
 }
 
 // Check if txt/JSON file or directory exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,34 +139,41 @@ function processDirectory(directory: string){
  */
 function processText(filepath: string, bookObj: books.objType): books.objType {
   const bookInfo = toolbox.getBookAndChapter(filepath);
-    if (bookInfo.bookName === "Placeholder") {
-      // Skip invalid files
-      return bookObj;
-    }
-
-    if (bookObj.content.length == 0) {
-      bookObj = toolbox.initializeBookObj(bookInfo.bookName, options.projectName);
-    }
-
-    const currentChapter = bookInfo.chapterNumber;
-    if (bookObj.content[currentChapter].type != "chapter") {
-      // Initialize current chapter
-      bookObj.content[currentChapter].type = "chapter";
-      bookObj.content[currentChapter].content = [];
-    }
-
-    toolbox.updateObj(bookObj, filepath, currentChapter);
-
-    // For single file parameter, write valid output
-    if (options.text && bookObj.header.bookInfo.code !== "000") {
-      // For testing, write out book JSON Object
-      writeJSON(bookObj);
-
-      //valid JSON Object to SFM
-      sfm.convertToSFM(bookObj);
-    }
-
+  const currentChapter = bookInfo.chapterNumber;
+  const bookType = books.getBookByName(bookInfo.bookName);
+  if (bookInfo.bookName === "Placeholder") {
+    // Skip invalid book name
+    console.warn('Skipping invalid book name');
     return bookObj;
+  } else if (currentChapter > bookType.chapters) {
+    // Skip invalid chapter number
+    console.warn('Skipping invalid chapter number ' + currentChapter + ' when ' +
+      bookObj.header.bookInfo.name + ' only has ' + bookType.chapters + ' chapters.');
+    return bookObj;
+  }
+
+  if (bookObj.content.length == 0) {
+    bookObj = toolbox.initializeBookObj(bookInfo.bookName, options.projectName);
+  }
+
+  if (bookObj.content[currentChapter].type != "chapter") {
+    // Initialize current chapter
+    bookObj.content[currentChapter].type = "chapter";
+    bookObj.content[currentChapter].content = [];
+  }
+
+  toolbox.updateObj(bookObj, filepath, currentChapter);
+
+  // For single file parameter, write valid output
+  if (options.text && bookObj.header.bookInfo.code !== "000") {
+    // For testing, write out book JSON Object
+    writeJSON(bookObj);
+
+    //valid JSON Object to SFM
+    sfm.convertToSFM(bookObj);
+  }
+
+  return bookObj;
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as program from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as books from './books';
 import * as toolbox from './toolbox';
 const {version} = require('../package.json');
 
@@ -53,7 +54,14 @@ if (options.json && !fs.existsSync(options.json)) {
 // End of parameters
 ////////////////////////////////////////////////////////////////////
 
-let bookObj = {};
+const b = new books.Books();
+let bookObj: books.objType = {
+  "header": {
+    "projectName" : "",
+    "bookInfo" : b.getBookByCode("000")
+  },
+  "content": []
+};
 
 const filesToParse: string[] = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,39 +108,41 @@ if (bookObj) {
   const VERSE_MARKER = "\\v ";
   const CRLF = "\n";
 
-  const chapters = bookObj['content'];
+  const chapters = bookObj.content;
 
   let SFMtext = "";
 
-  SFMtext += ID_MARKER + bookObj['header']['bookInfo']['code'] + ' ' +  bookObj['header']['projectName'] + CRLF;
+  SFMtext += ID_MARKER + bookObj.header.bookInfo.code + ' ' +  bookObj.header.projectName + CRLF;
   SFMtext += USFM_MARKER + '3.0' + CRLF;
-  SFMtext += HEADER_MARKER + bookObj['header']['bookInfo']['name'] + CRLF;
-  SFMtext += TOC_MARKER + bookObj['header']['bookInfo']['name'] + CRLF;
-  SFMtext += MAIN_TITLE_MARKER + bookObj['header']['bookInfo']['name'] + CRLF;
+  SFMtext += HEADER_MARKER + bookObj.header.bookInfo.name + CRLF;
+  SFMtext += TOC_MARKER + bookObj.header.bookInfo.name + CRLF;
+  SFMtext += MAIN_TITLE_MARKER + bookObj.header.bookInfo.name + CRLF;
 
 
   chapters.forEach(function(chapter) {
-    if(chapter['number'] != 0){
-      SFMtext += CHAPTER_MARKER + chapter['number'] as string + CRLF;
-      const sectionsAndVerses = chapter['content'];
-      sectionsAndVerses.forEach(function(snippet) {
-        switch(snippet['type']) {
-          case "section":
-            SFMtext += SECTION_MARKER + snippet['text'] + PARAGRAPH_MARKER + CRLF;
-            break;
-          case "verse":
-            SFMtext += VERSE_MARKER + snippet['number'] as string + ' ' + snippet['text'] + CRLF;
-            break;
-          default:
-            throw 'Invalid type on ' + JSON.stringify(snippet) + '. \nLooking for "section" or "verse".';
-        }
-      });
+    if(chapter.number != 0){
+      SFMtext += CHAPTER_MARKER + chapter.number + CRLF;
+      if(chapter.content){
+        const sectionsAndVerses = chapter.content;
+        sectionsAndVerses.forEach(function(unit) {
+          switch(unit.type) {
+            case "section":
+              SFMtext += SECTION_MARKER + unit.text + PARAGRAPH_MARKER + CRLF;
+              break;
+            case "verse":
+              SFMtext += VERSE_MARKER + unit.number + ' ' + unit.text + CRLF;
+              break;
+            default:
+              throw 'Invalid type on ' + JSON.stringify(unit) + '. \nLooking for "section" or "verse".';
+          }
+        });
+      }
     }
   });
 
-  const bookNum = bookObj['header']['bookInfo']['num'];
-  const bookCode = bookObj['header']['bookInfo']['code'];
-  const projectName = bookObj['header']['projectName'];
+  const bookNum = bookObj.header.bookInfo.num;
+  const bookCode = bookObj.header.bookInfo.code;
+  const projectName = bookObj.header.projectName;
   fs.writeFileSync('./' + bookNum + bookCode + projectName + '.SFM', SFMtext);
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,12 +111,32 @@ if (options.json) {
   }
 } else if (filesToParse.length > 0) {
   filesToParse.forEach(file => {
-    bookObj = toolbox.parse(file, "slt");
+    const bookInfo = toolbox.getBookAndChapter(file);
+    if (bookInfo.bookName === "") {
+      // Skip invalid files
+      return;
+    }
+
+    if (bookObj.content.length == 0) {
+      bookObj = toolbox.initializeBookObj(bookInfo.bookName, options.projectName);
+    }
+
+    const currentChapter = bookInfo.chapterNumber;
+    if (bookObj.content[currentChapter].type != "chapter") {
+      // Initialize current chapter
+      bookObj.content[currentChapter].type = "chapter";
+      bookObj.content[currentChapter].content = [];
+    }
+
+    toolbox.updateObj(bookObj, file, currentChapter);
   });
   // For testing, write out each book's JSON to file
+  fs.writeFileSync('./' + bookObj.header.bookInfo.num +
+    bookObj.header.bookInfo.code + bookObj.header.projectName + '.json', JSON.stringify(bookObj, null, 2));
+  console.info('Writing out book object');
 
 } else {
-  console.warn("No directory or JSON file given. Exiting");
+  console.warn("No input files provided. Exiting");
   process.exit(1)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ let bookObj = {};
 
 if (options.text) {
   // Parse a txt file into JSON Object
-  bookObj = toolbox.parse(options.text);
+  bookObj = toolbox.parse(options.text, "slt");
 
   // For testing, write out each book's JSON to file
 
@@ -76,8 +76,53 @@ if (options.text) {
   process.exit(1)
 }
 
-// Write out the JSON Objects to SFM
 
+
+// Write out the JSON Objects to SFM
 if (bookObj) {
-  console.log("bookObj: " + JSON.stringify(bookObj));
+
+  const ID_MARKER = "\\id ";
+  const USFM_MARKER = "\\usfm ";
+  const HEADER_MARKER = "\\h ";
+  const TOC_MARKER = "\\toc ";
+  const MAIN_TITLE_MARKER = "\\mt ";
+  const CHAPTER_MARKER = "\\c ";
+  const SECTION_MARKER = "\\s1 ";
+  const VERSE_MARKER = "\\v ";
+  const CRLF = "\n";
+
+  const chapters = bookObj['content'];
+
+  //let outputFileName = options.text + '.SFM';
+  let SFMtext = "";
+
+  SFMtext += ID_MARKER + bookObj['header']['bookInfo']['code'] + ' ' +  bookObj['header']['projectName'] + CRLF;
+  SFMtext += USFM_MARKER + '3.0' + CRLF;
+  SFMtext += HEADER_MARKER + bookObj['header']['bookInfo']['name'] + CRLF;
+  SFMtext += TOC_MARKER + bookObj['header']['bookInfo']['name'] + CRLF;
+  SFMtext += MAIN_TITLE_MARKER + bookObj['header']['bookInfo']['name'] + CRLF;
+
+
+  chapters.forEach(function(chapter) {
+    if(chapter['number'] != 0){
+      SFMtext += CHAPTER_MARKER + chapter['number'] as string + CRLF;
+      const sectionsAndVerses = chapter['content'];
+      sectionsAndVerses.forEach(function(snippet) {
+        switch(snippet['type']) {
+          case "section":
+            SFMtext += SECTION_MARKER + snippet['text'] + CRLF;
+            break;
+          case "verse":
+            SFMtext += VERSE_MARKER + snippet['number'] as string + ' ' + snippet['text'] + CRLF;
+            break;
+          default:
+            throw 'Invalid type on ' + JSON.stringify(snippet) + '. \nLooking for "section" or "verse".';
+        }
+      });
+    }
+  });
+
+  // TODO: project name variable
+  fs.writeFileSync('./' + (options.json.replace(/^.*[\\/]/, '')).replace('.json', '.SFM') + "slt", SFMtext);
+
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,21 +74,20 @@ if (options.superDirectory && !fs.existsSync(options.superDirectory)) {
 // Routing commands to functions
 ////////////////////////////////////////////////////////////////////
 
-const b = new books.Books();
-let bookObj: books.objType = {
-  "header": {
-    "projectName" : "",
-    "bookInfo" : b.getBookByCode("000")
-  },
-  "content": []
-};
-
 if (options.json) {
   // Make a JSON object into an SFM file
   processJSON(options.json);
 } else if (options.text) {
   // Parse a txt file into a JSON object
-  processText(options.text);
+  const b = new books.Books();
+  const bookObj: books.objType = {
+    "header": {
+      "projectName" : "",
+      "bookInfo" : b.getBookByCode("000")
+    },
+    "content": []
+  };
+  processText(options.text, bookObj);
 } else if (options.directory) {
   // Convert the text files in a directory into an SFM book file
   processDirectory(options.directory);
@@ -120,10 +119,19 @@ function processSuperDirectory(superDirectory: string){
  * @param {string} directory - path to directory containing text files
  */
 function processDirectory(directory: string){
+  const b = new books.Books();
+  const bookObj: books.objType = {
+    "header": {
+      "projectName" : "",
+      "bookInfo" : b.getBookByCode("000")
+    },
+    "content": []
+  };
+  // Get all the text files in the directory and then process them
   const filesToParse: string[] = [];
   fileAssistant.getTextFilesInside(directory, filesToParse);
   filesToParse.forEach(file => {
-    processText(file);
+    processText(file, bookObj);
   });
 
   // Write out valid JSON Object to SFM
@@ -137,7 +145,7 @@ function processDirectory(directory: string){
  * Take a text file and make a JSON book type object
  * @param {string} filepath - file path of a single text file
  */
-function processText(filepath: string) {
+function processText(filepath: string, bookObj: books.objType) {
   const bookInfo = toolbox.getBookAndChapter(filepath);
     if (bookInfo.bookName === "Placeholder") {
       // Skip invalid files
@@ -169,7 +177,14 @@ function processText(filepath: string) {
  * @param {string} filepath - file path of a single JSON file
  */
 function processJSON(filepath: string){
-
+  const b = new books.Books();
+  let bookObj: books.objType = {
+    "header": {
+      "projectName" : "",
+      "bookInfo" : b.getBookByCode("000")
+    },
+    "content": []
+  };
   try {
     bookObj = require(filepath);
   } catch (e) {

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -1,0 +1,58 @@
+import * as books from './books';
+import * as fs from 'fs';
+
+/**
+ * Parse a JSON file and converts it to USFM
+ * @param {Books.objType} bookObj - a book type of JSON object
+ */
+export function convertToSFM(bookObj: books.objType) : any {
+
+  const ID_MARKER = "\\id ";
+  const USFM_MARKER = "\\usfm ";
+  const HEADER_MARKER = "\\h ";
+  const TOC_MARKER = "\\toc ";
+  const MAIN_TITLE_MARKER = "\\mt ";
+  const CHAPTER_MARKER = "\\c ";
+  const SECTION_MARKER = "\\s1 ";
+  const PARAGRAPH_MARKER = "\n\\p";
+  const VERSE_MARKER = "\\v ";
+  const CRLF = "\n";
+
+  const chapters = bookObj.content;
+
+  let SFMtext = "";
+
+  SFMtext += ID_MARKER + bookObj.header.bookInfo.code + ' ' +  bookObj.header.projectName + CRLF;
+  SFMtext += USFM_MARKER + '3.0' + CRLF;
+  SFMtext += HEADER_MARKER + bookObj.header.bookInfo.name + CRLF;
+  SFMtext += TOC_MARKER + bookObj.header.bookInfo.name + CRLF;
+  SFMtext += MAIN_TITLE_MARKER + bookObj.header.bookInfo.name + CRLF;
+
+
+  chapters.forEach(function(chapter) {
+    if(chapter.number != 0){
+      SFMtext += CHAPTER_MARKER + chapter.number + CRLF;
+      if(chapter.content){
+        const sectionsAndVerses = chapter.content;
+        sectionsAndVerses.forEach(function(unit) {
+          switch(unit.type) {
+            case "section":
+              SFMtext += SECTION_MARKER + unit.text + PARAGRAPH_MARKER + CRLF;
+              break;
+            case "verse":
+              SFMtext += VERSE_MARKER + unit.number + ' ' + unit.text + CRLF;
+              break;
+            default:
+              throw 'Invalid type on ' + JSON.stringify(unit) + '. \nLooking for "section" or "verse".';
+          }
+        });
+      }
+    }
+  });
+
+  const bookNum = bookObj.header.bookInfo.num;
+  const bookCode = bookObj.header.bookInfo.code;
+  const projectName = bookObj.header.projectName;
+  fs.writeFileSync('./' + bookNum + bookCode + projectName + '.SFM', SFMtext);
+
+}

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -1,3 +1,5 @@
+// Copyright 2022 SIL International
+// Utilities for converting a JSON file to USFM
 import * as books from './books';
 import * as fs from 'fs';
 

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
  * Parse a JSON file and converts it to USFM
  * @param {Books.objType} bookObj - a book type of JSON object
  */
-export function convertToSFM(bookObj: books.objType) : any {
+export function convertToSFM(bookObj: books.objType) {
 
   const ID_MARKER = "\\id ";
   const USFM_MARKER = "\\usfm ";
@@ -55,5 +55,4 @@ export function convertToSFM(bookObj: books.objType) : any {
   const projectName = bookObj.header.projectName;
   const padZero = bookObj.header.bookInfo.num < 10 ? '0': '';
   fs.writeFileSync('./' + padZero + bookNum + bookCode + projectName + '.SFM', SFMtext);
-
 }

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -53,6 +53,7 @@ export function convertToSFM(bookObj: books.objType) : any {
   const bookNum = bookObj.header.bookInfo.num;
   const bookCode = bookObj.header.bookInfo.code;
   const projectName = bookObj.header.projectName;
-  fs.writeFileSync('./' + bookNum + bookCode + projectName + '.SFM', SFMtext);
+  const padZero = bookObj.header.bookInfo.num < 10 ? '0': '';
+  fs.writeFileSync('./' + padZero + bookNum + bookCode + projectName + '.SFM', SFMtext);
 
 }

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -13,7 +13,7 @@ export function convertToSFM(bookObj: books.objType) {
   const TOC_MARKER = "\\toc ";
   const MAIN_TITLE_MARKER = "\\mt ";
   const CHAPTER_MARKER = "\\c ";
-  const SECTION_MARKER = "\\s1 ";
+  const SECTION_MARKER = "\\s"; // number gets added later
   const PARAGRAPH_MARKER = "\n\\p";
   const VERSE_MARKER = "\\v ";
   const CRLF = "\n";
@@ -37,7 +37,7 @@ export function convertToSFM(bookObj: books.objType) {
         sectionsAndVerses.forEach(function(unit) {
           switch(unit.type) {
             case "section":
-              SFMtext += SECTION_MARKER + unit.text + PARAGRAPH_MARKER + CRLF;
+              SFMtext += SECTION_MARKER + unit.number + ' ' + unit.text + PARAGRAPH_MARKER + CRLF;
               break;
             case "verse":
               SFMtext += VERSE_MARKER + unit.number + ' ' + unit.text + CRLF;

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -117,7 +117,7 @@ export function initializeBookObj(bookName: string, projectName: string) : books
 export function updateObj(bookObj: books.objType, file: string, currentChapter: number) {
   // Read in Toolbox file and strip out empty lines (assuming Windows line-endings)
   let toolboxFile = fs.readFileSync(file, 'utf-8');
-  toolboxFile = toolboxFile.replace(/(\r\n){2,}/g, '\r\n');
+  toolboxFile = toolboxFile.replace(/(\r\n?){2,}/g, '\r\n');
   const toolboxData = toolboxFile.split(/\r\n?/);
   if (toolboxData[toolboxData.length - 1] == '') {
     // If last line empty, remove it
@@ -179,6 +179,10 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
             console.warn('Skipping unexpected marker:' + marker);
         }
       } else if (mode == 'VS_AS_VERSE') {
+        if (marker != "\\tx" && marker != "\\vs") {
+          // Skip all other markers for now
+          return;
+        }
         // Determine if any other \\vs special processing needed
         let vs_other = false, vs_section_header = false;
         if (marker == '\\vs') {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -5,6 +5,15 @@ import * as path from 'path'
 import * as books from './books';
 
 /**
+ * Enum to know what mode to parse the Toolbox file
+ * TX_AS_VERSE - each \tx is a separate verse
+ * VS_AS_VERSE - depend on \vs to mark verse numbers
+ */
+type modeType =
+  "TX_AS_VERSE" |
+  "VS_AS_VERSE";
+
+/**
  * List of recognized (escaped) Toolbox markers. We only process some of them
  */
 export type markerType =
@@ -100,6 +109,19 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
     // If last line empty, remove it
     toolboxData.pop();
   }
+
+  // Determine the mode of how to process the file
+  let mode: modeType = 'TX_AS_VERSE';
+  const modePattern = /\\vs\s+\d+/;
+  toolboxData.every(line => {
+    if (line.match(modePattern)) {
+      // Change mode and break out
+      mode = 'VS_AS_VERSE';
+      return false;
+    }
+    // Continue the very() loop
+    return true;
+  });
 
   // Split each line on type and content
   const pattern = /(\\[A-Za-z]+)\s(.*)/;

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -33,15 +33,17 @@ export function getBookAndChapter(file: string) : fileInfoType {
   const pattern = /([0-9A-Za-z]+)_(Ch|ch)?(\d+)[_\s]?.*\.txt/;
   const match = filename.match(pattern);
   const obj: fileInfoType = {
-    bookName: "",
+    bookName: "Placeholder",
     chapterNumber: 0
   };
   if (match) {
     // Fix any typo in book name
     const b = new books.Books();
     const bookName = b.getBookByName(match[1]).name;
-    obj.bookName = bookName;
-    obj.chapterNumber = parseInt(match[3]);
+    if (bookName !== "Placeholder") {
+      obj.bookName = bookName;
+      obj.chapterNumber = parseInt(match[3]);
+    }
   } else {
     console.warn('Unable to determine info from: ' + filename);
   }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -148,4 +148,3 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
 
   });
 }
-

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -115,7 +115,7 @@ export function initializeBookObj(bookName: string, projectName: string) : books
  * @param {number} currentChapter - Book chapter to modify
  */
 export function updateObj(bookObj: books.objType, file: string, currentChapter: number) {
-  // Read in Toolbox file and strip out empty lines (assuming Windows line-endings)
+  // Read in Toolbox file and strip out empty lines
   let toolboxFile = fs.readFileSync(file, 'utf-8');
   toolboxFile = toolboxFile.replace(/(\r\n?){2,}/g, '\r\n');
   const toolboxData = toolboxFile.split(/\r\n?/);
@@ -247,7 +247,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
         // Process the action
         switch(action) {
           case 'START' :
-            console.warn('action: START unexpected');
+            console.warn(`action: START unexpected while parsing "${file}"`);
             break;
           case 'CREATE_NEW_VERSE' :
             // Create new verse and add

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -118,7 +118,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
   // Read in Toolbox file and strip out empty lines (assuming Windows line-endings)
   let toolboxFile = fs.readFileSync(file, 'utf-8');
   toolboxFile = toolboxFile.replace(/(\r\n){2,}/g, '\r\n');
-  const toolboxData = toolboxFile.split(/\r?\n/);
+  const toolboxData = toolboxFile.split(/\r\n?/);
   if (toolboxData[toolboxData.length - 1] == '') {
     // If last line empty, remove it
     toolboxData.pop();

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -2,6 +2,15 @@
 // Types and utilities for handling Toolbox text file
 import * as fs from 'fs';
 import * as path from 'path'
+import * as books from './books';
+
+/**
+ * List of recognized (escaped) Toolbox markers
+ */
+export type lineType =
+  "\\c" |
+  "\\tx" |
+  "\\vs";
 
 /**
  * Information about the Toolbox text file based on the filename
@@ -10,10 +19,26 @@ export interface fileInfoType {
   bookName: string;
   chapterNumber: number;
 }
+
+export interface unitType {
+  type: string,
+  number: number,
+  content?: any,
+  text?: string
+}
+
+export interface objType {
+  header: {
+    projectName: string,
+    bookInfo:  books.bookType
+  },
+  content: unitType[]
+}
+
 /**
  * Extract a book name and chapter number from the filename
  * @param {string} file - Path to the Toolbox text file
- * @returns {Object} - Object containing the book name and chapter number
+ * @returns {fileInfoType} - Object containing the book name and chapter number
  */
 export function getBookAndChapter(file: string) : fileInfoType {
   const filename = path.parse(file).base;
@@ -24,8 +49,11 @@ export function getBookAndChapter(file: string) : fileInfoType {
     chapterNumber: 0
   };
   if (match) {
-    obj.bookName = match[1];
-    obj.chapterNumber = parseInt(match[2])
+    // Fix any typo in book name
+    const b = new books.Books();
+    const bookName = b.getBookByName(match[1]).name;
+    obj.bookName = bookName;
+    obj.chapterNumber = parseInt(match[2]);
   } else {
     console.warn('Unable to determine info from: ' + filename);
   }
@@ -36,19 +64,69 @@ export function getBookAndChapter(file: string) : fileInfoType {
 /**
  * Parse a Toolbox text file and convert it to JSON
  * @param {string} file - Path to the Toolbox text file
+ * @param {string} projectName - Name of the Paratext project
  * @returns {Object} - Object containing the chapter information
  */
-export function parse(file: string) : any {
+export function parse(file: string, projectName: string) : any {
   const bookInfo = getBookAndChapter(file);
+  const currentChapter = bookInfo.chapterNumber;
+  const b = new books.Books();
+  const bookType = b.getBookByName(bookInfo.bookName);
 
-  // Read in Toolbox file and strip out empty lines
+  // Intialize book object and content for the number of chapters
+  const bookObj : objType = {
+    "header": {
+      "projectName" : projectName,
+      "bookInfo" : bookType
+    },
+    "content": []
+  };
+
+  // Intialize book object with padding for each chapter (index 0 is extra padding)
+  for (let i = 0; i < bookType.chapters+1; i++) {
+    const padding = {
+      "type": "padding",
+      "number": i
+    };
+    bookObj.content.push(padding);
+  }
+
+  // Read in Toolbox file and strip out empty lines (assuming Windows line-endings)
   let toolboxFile = fs.readFileSync(file, 'utf-8');
-  toolboxFile = toolboxFile.replace(/\n{2,}/g, '\n');
+  toolboxFile = toolboxFile.replace(/(\r\n){2,}/g, '\r\n');
   const toolboxData = toolboxFile.split(/\r?\n/);
+  if (toolboxData[toolboxData.length - 1] == '') {
+    // If last line empty, remove it
+    toolboxData.pop();
+  }
 
-  // Parse each line
+  // Split each line on type and content
+  const pattern = new RegExp(/^(\\[A-Za-z]+)\s(.)*$/);
   toolboxData.forEach(line => {
-    console.info('');
+    //
+    const match = line.match(pattern);
+    if (match) {
+      const type: string = match[1];
+      const content: string = match[2];
+      switch (type) {
+        case '\\c' :
+          break;
+        case '\\tx' :
+          // Assume we're adding a verse
+
+          break;
+        case '\\vs' :
+          // Convert previous line from "verse" to "section"
+
+          break;
+        default:
+          console.warn('Unexepcted line type:' + type);
+      }
+
+    } else {
+      console.warn('Unable to parse line: ' + line);
+    }
+
   });
   return {};
 }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -27,7 +27,7 @@ export interface fileInfoType {
  */
 export function getBookAndChapter(file: string) : fileInfoType {
   const filename = path.parse(file).base;
-  const pattern = new RegExp(/^([A-Za-z]+)_Ch(\d+)_.*\.txt$/);
+  const pattern = /([A-Za-z]+)_(Ch)?(\d+)[_\s].*\.txt$/;
   const match = filename.match(pattern);
   const obj: fileInfoType = {
     bookName: "",
@@ -38,7 +38,7 @@ export function getBookAndChapter(file: string) : fileInfoType {
     const b = new books.Books();
     const bookName = b.getBookByName(match[1]).name;
     obj.bookName = bookName;
-    obj.chapterNumber = parseInt(match[2]);
+    obj.chapterNumber = parseInt(match[3]);
   } else {
     console.warn('Unable to determine info from: ' + filename);
   }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -141,7 +141,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
   const markerPattern = /(\\[A-Za-z]+)\s(.*)/;
   let verseNum = 1; // Keep track of the current verse to write
   let action : actionType = 'START';
-  //let mostRecentTXcontent = "";
+  let section_title_written = false;
   toolboxData.forEach(line => {
     const lineMatch = line.match(markerPattern);
     if (lineMatch) {
@@ -271,9 +271,12 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
             break;
           }
           case 'MODIFY_VERSE_TO_SECTION' :
-            // Convert previous line from "verse" to "section", number "1"
+            // Convert previous line from "verse" to "section".
+            // Use section number 1 the first time section is written for the chapter
             bookObj.content[currentChapter].content[contentLength - 1].type = "section";
-            bookObj.content[currentChapter].content[contentLength - 1].number = 1;
+            bookObj.content[currentChapter].content[contentLength - 1].number =
+              (section_title_written) ? 2 : 1;
+            section_title_written = true;
             break;
         }
       }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -49,7 +49,14 @@ export function getBookAndChapter(file: string) : fileInfoType {
   return obj;
 }
 
-export function initializeBookObj(bookName: string, projectName: string) : any {
+/**
+ *
+ * @param {string} bookName - canonical book name
+ * @param {string} projectName - Paratext project name
+ * @returns {books.objType} - Initialized object for the current book,
+ *         with padding for the expected number of chapters
+ */
+export function initializeBookObj(bookName: string, projectName: string) : books.objType {
   const b = new books.Books();
   const bookType = b.getBookByName(bookName);
 

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -8,7 +8,10 @@ import * as books from './books';
  * List of recognized (escaped) Toolbox markers
  */
 export type markerType =
+  // These are ignored
   "\\c" |
+
+  // These are processed
   "\\tx" |
   "\\vs";
 
@@ -27,7 +30,7 @@ export interface fileInfoType {
  */
 export function getBookAndChapter(file: string) : fileInfoType {
   const filename = path.parse(file).base;
-  const pattern = /([A-Za-z]+)_(Ch)?(\d+)[_\s].*\.txt$/;
+  const pattern = /([0-9A-Za-z]+)_(Ch|ch)?(\d+)[_\s]?.*\.txt/;
   const match = filename.match(pattern);
   const obj: fileInfoType = {
     bookName: "",
@@ -106,6 +109,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
 
       switch (marker) {
         case '\\c' :
+          // Markers to ignore
           break;
         case '\\tx' :
           // Assume we're adding a verse
@@ -130,7 +134,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
       }
 
     } else {
-      console.warn('Unable to parse line: ' + line);
+      console.warn(`Unable to parse line: "${line}" from "${file}" - skipping...`);
     }
 
   });

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -20,21 +20,6 @@ export interface fileInfoType {
   chapterNumber: number;
 }
 
-export interface unitType {
-  type: string,
-  number: number,
-  content?: any,
-  text?: string
-}
-
-export interface objType {
-  header: {
-    projectName: string,
-    bookInfo:  books.bookType
-  },
-  content: unitType[]
-}
-
 /**
  * Extract a book name and chapter number from the filename
  * @param {string} file - Path to the Toolbox text file
@@ -66,7 +51,7 @@ export function initializeBookObj(bookName: string, projectName: string) : any {
   const bookType = b.getBookByName(bookName);
 
   // Initialize book object and content for the number of chapters
-  const bookObj : objType = {
+  const bookObj : books.objType = {
     "header": {
       "projectName" : projectName,
       "bookInfo" : bookType
@@ -108,7 +93,7 @@ export function parse(file: string, projectName: string) : any {
   }
 
   // Split each line on type and content
-  const pattern = new RegExp(/^(\\{2}[A-Za-z]+)\s(.*)$/);
+  const pattern = new RegExp(/^(\\[A-Za-z]+)\s(.*)$/);
   toolboxData.forEach(line => {
     const match = line.match(pattern);
     if (match) {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -5,15 +5,16 @@ import * as path from 'path'
 import * as books from './books';
 
 /**
- * List of recognized (escaped) Toolbox markers
+ * List of recognized (escaped) Toolbox markers. We only process some of them
  */
 export type markerType =
-  // These are ignored
-  "\\c" |
-
   // These are processed
   "\\tx" |
-  "\\vs";
+  "\\vs" |
+
+  // These are ignored
+  "\\c" |
+  "\\t";
 
 /**
  * Information about the Toolbox text file based on the filename
@@ -38,8 +39,7 @@ export function getBookAndChapter(file: string) : fileInfoType {
   };
   if (match) {
     // Fix any typo in book name
-    const b = new books.Books();
-    const bookName = b.getBookByName(match[1]).name;
+    const bookName = books.getBookByName(match[1]).name;
     if (bookName !== "Placeholder") {
       obj.bookName = bookName;
       obj.chapterNumber = parseInt(match[3]);
@@ -59,8 +59,7 @@ export function getBookAndChapter(file: string) : fileInfoType {
  *         with padding for the expected number of chapters
  */
 export function initializeBookObj(bookName: string, projectName: string) : books.objType {
-  const b = new books.Books();
-  const bookType = b.getBookByName(bookName);
+  const bookType = books.getBookByName(bookName);
 
   // Initialize book object and content for the number of chapters
   const bookObj : books.objType = {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -14,7 +14,8 @@ export type markerType =
 
   // These are ignored
   "\\c" |
-  "\\t";
+  "\\ref" |
+  "\\t" ;
 
 /**
  * Information about the Toolbox text file based on the filename
@@ -138,7 +139,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
 
           break;
         default:
-          console.warn('Unexpected line type:' + marker);
+          console.warn('Skipping unexpected marker:' + marker);
       }
 
     } else {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -101,7 +101,7 @@ export function parse(file: string, projectName: string) : any {
   }
 
   // Split each line on type and content
-  const pattern = new RegExp(/^(\\[A-Za-z]+)\s(.)*$/);
+  const pattern = new RegExp(/^(\\\w+)\s(.*)$/);
   toolboxData.forEach(line => {
     //
     const match = line.match(pattern);

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -73,7 +73,7 @@ export function parse(file: string, projectName: string) : any {
   const b = new books.Books();
   const bookType = b.getBookByName(bookInfo.bookName);
 
-  // Intialize book object and content for the number of chapters
+  // Initialize book object and content for the number of chapters
   const bookObj : objType = {
     "header": {
       "projectName" : projectName,
@@ -82,7 +82,7 @@ export function parse(file: string, projectName: string) : any {
     "content": []
   };
 
-  // Intialize book object with padding for each chapter (index 0 is extra padding)
+  // Initialize book object with padding for each chapter (index 0 is extra padding)
   for (let i = 0; i < bookType.chapters+1; i++) {
     const padding = {
       "type": "padding",
@@ -120,7 +120,7 @@ export function parse(file: string, projectName: string) : any {
 
           break;
         default:
-          console.warn('Unexepcted line type:' + type);
+          console.warn('Unexpected line type:' + type);
       }
 
     } else {


### PR DESCRIPTION
# Convert Toolbox text files to SFM (USFM) files suitable for Paratext #

This program enables those with scripture books in Toolbox format to transition to SFM format for use with Paratext translation editing software. 

`npm run publish` creates an executable file that can be run with an argument of either one text file, a directory of text files for one book, or a super-directory of book directories. It writes each Scripture book as an SFM file stored in the current directory. 

This program handles both Windows and Linux/Mac OS line endings, and works for a variety of toolbox formats, taking \tx lines and \vs lines in different configurations to create JSONs with chapters and verses, which are then converted into the SFM files.

Developers can use node dist/index.js to run the program.

[USFM Documentation](https://ubsicap.github.io/usfm/)
