### PR TITLE
feat: Write logging output to "Extra Book A"

### DIFF
--- a/src/books.ts
+++ b/src/books.ts
@@ -5,6 +5,7 @@
  * 3-character book code that Paratext uses (from BookNames.xml).
  * "000" is a placeholder for book number 0 so that book number matches index.
  *       (not a valid Paratext book code)
+ * "XXA" to "XXG" are extra books that can be used for SFM Console logging.
  */
 export type CodeType =
   // Placeholder
@@ -25,12 +26,17 @@ export type CodeType =
   "GAL" | "EPH" | "PHP" | "COL" |
   "1TH" | "2TH" | "1TI" | "2TI" |
   "TIT" | "PHM" | "HEB" | "JAS" | "1PE" | "2PE" |
-  "1JN" | "2JN" | "3JN" | "JUD" | "REV";
+  "1JN" | "2JN" | "3JN" | "JUD" | "REV" |
+
+  // Extra books for logging
+  "XXA" | "XXB" | "XXC" | "XXD" | "XXE" | "XXF" | "XXG";
 
 export interface bookType {
-  code: CodeType;   // 3-character book code
+  code: CodeType;   // 3-character book indentifier as defined by
+                    // https://ubsicap.github.io/usfm/identification/books.html
   name: string;     // Book name
-  num: number;      // Book number
+  num: number;      // Book number as defined by
+                    // https://ubsicap.github.io/usfm/identification/books.html
   chapters: number; // Total number of chapters in the book
   versesInChapter: number[]; // Number of verses in each chapter (placeholder at 0)
   verses: number;   // Total number of verses in the book
@@ -41,7 +47,7 @@ export interface bookType {
  * Array of bookType containing information about each book
 */
 export const bookInfo: bookType[] = [
-{
+  {
     // Just a placeholder. Not a valid book
     code: "000",
     name: "Placeholder",
@@ -674,6 +680,64 @@ export const bookInfo: bookType[] = [
                          19, 17, 18, 20,  8, 21, 18, 24, 21, 15,
                          27, 21],
     verses: 404
+  },
+
+  // Extra books for logging
+  {
+    code: "XXA",
+    name: "Extra Book A",
+    num: 94,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
+  },
+  {
+    code: "XXB",
+    name: "Extra Book B",
+    num: 95,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
+  },
+  {
+    code: "XXC",
+    name: "Extra Book C",
+    num: 96,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
+  },
+  {
+    code: "XXD",
+    name: "Extra Book D",
+    num: 97,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
+  },
+  {
+    code: "XXE",
+    name: "Extra Book E",
+    num: 98,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
+  },
+  {
+    code: "XXF",
+    name: "Extra Book F",
+    num: 99,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
+  },
+  {
+    code: "XXG",
+    name: "Extra Book G",
+    num: 100,
+    chapters: 999,
+    versesInChapter: [0],
+    verses: 0
   }
 ];
 //#endregion

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@
 // Copyright 2022 SIL International
 import * as program from 'commander';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as books from './books';
 import * as toolbox from './toolbox';
 import * as sfm from './sfm';
+import * as sfmConsole from './sfmConsole';
 import * as fileAssistant from './fileAssistant';
 const {version} = require('../package.json');
 
@@ -52,6 +52,9 @@ if (!options.projectName) {
   process.exit(1);
 }
 
+// Initialize the logger to use "Extra Book A"
+const s = new sfmConsole.SFMConsole(options.projectName, 'XXA');
+
 // Check if txt/JSON file or directory exists
 if (options.text && !fs.existsSync(options.text)) {
   console.error("Can't open Toolbox text file " + options.text);
@@ -95,6 +98,8 @@ if (options.json) {
   processSuperDirectory(options.superDirectory);
 }
 
+// Write SFM Console log to extra book file
+s.writeLog();
 
 ////////////////////////////////////////////////////////////////////
 // Processor functions
@@ -172,7 +177,7 @@ function processText(filepath: string, bookObj: books.objType): books.objType {
     bookObj.content[currentChapter].content = [];
   }
 
-  toolbox.updateObj(bookObj, filepath, currentChapter, debugMode);
+  toolbox.updateObj(bookObj, filepath, currentChapter, s, debugMode);
 
   // For single file parameter, write valid output
   if (options.text && bookObj.header.bookInfo.code !== "000") {

--- a/src/sfmConsole.ts
+++ b/src/sfmConsole.ts
@@ -1,0 +1,84 @@
+// Copyright 2023 SIL International
+// Utility to write to console along with "Extra Book A" SFM file.
+import * as books from './books';
+import * as fs from 'fs';
+
+/**
+ * Console level
+ */
+export type consoleType = 
+  "warn" | "info" | "log" | "error";
+
+export type consoleUnitType = {
+  type: consoleType;
+  text: string;
+}
+
+export class SFMConsole {
+  projectName: string;                   // Name of the PTX Project
+  private loggingObj: consoleUnitType[]; // Object to contain logging info
+  private extraBook: books.bookType;     // Info on which PTX extra book to use for logging
+
+  constructor(projectName: string, bookCode: books.CodeType) {
+    this.projectName = projectName;
+    this.loggingObj = [];
+
+    this.extraBook = books.getBookByCode(bookCode);
+    if (this.extraBook.num < 94 || this.extraBook.num > 100) {
+      console.error(`SFMConsole(): Book code ${bookCode} is not between Extra Book A (XXA) and Extra Book G (XXG)`);
+    }
+  }
+
+  /**
+   * Append to log
+   * @param {consoleType} mode - level to write to console
+   * @param {string} text - string to write to console and log
+   */
+  public log(mode: consoleType, text: string) {
+    switch(mode) {
+      case "warn" :
+        console.warn(text);
+        break;
+      case "info" :
+        console.info(text);
+        break;
+      case "log" :
+        console.log(text);
+        break;
+      case "error" :
+        console.error(text);
+        break;
+      default:
+        console.error(`SFMConsole(): Unxepected write mode: ${mode}\n`);
+    }
+
+    const unit: consoleUnitType = {
+      type: mode,
+      text: text
+    };
+    if (this.loggingObj) {
+      this.loggingObj.push(unit);
+    } else {
+      console.error(`SFMConsole() loggingObj not initialized`);
+    }
+  }
+
+  /**
+   * Write content of log to extra book file
+   */
+  public writeLog() {
+    const LOGFILE =  './' + this.extraBook.num + this.extraBook.code + this.projectName + '.SFM';
+    console.info(`Init on log ${process.cwd()} ${LOGFILE}`);
+    if (fs.existsSync(LOGFILE)) {
+      console.warn("Overwriting log file: " + LOGFILE);
+    }
+    
+    const HEADER = '\\id ' + this.extraBook.code + ' - ' + this.projectName + '\n';
+    let content = HEADER;
+    this.loggingObj.forEach(l => {
+      content += '\\rem ' + l.type + ': ' + l.text + '\n';
+    });
+
+    fs.writeFileSync(LOGFILE, content);
+  }
+}

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -3,6 +3,7 @@
 import * as fs from 'fs';
 import * as path from 'path'
 import * as books from './books';
+import * as sfmConsole from './sfmConsole';
 
 /**
  * Enum to know what mode to parse the Toolbox file
@@ -117,9 +118,11 @@ export function initializeBookObj(bookName: string, projectName: string) : books
  * @param {book.objType} bookObj - Book object to modify
  * @param {string} file - Path to the Toolbox text file
  * @param {number} currentChapter - Book chapter to modify
+ * @param {sfmConsole.SFMConsole} - Object that maintains logging
  * @param {boolean} debugMode - Whether to print additional logging
  */
-export function updateObj(bookObj: books.objType, file: string, currentChapter: number, debugMode = false) {
+export function updateObj(bookObj: books.objType, file: string, currentChapter: number,
+    s: sfmConsole.SFMConsole, debugMode = false) {
   // Read in Toolbox file and strip out empty lines
   let toolboxFile = fs.readFileSync(file, 'utf-8');
   toolboxFile = toolboxFile.replace(/(\r\n?){2,}/g, '\r\n');
@@ -242,7 +245,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
             }
           } else {
             // Skip unrecognized \vs line
-            console.warn(`${bookObj.header.bookInfo.name} ch ${currentChapter}: Skipping unrecognized line "${line}".`);
+            s.log('warn', `${bookObj.header.bookInfo.name} ch ${currentChapter}: Skipping unrecognized line "${line}".`);
             return;
           }
         }
@@ -349,7 +352,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
       }
     } else {
       if (lineMatch && lineMatch[2] != '') {
-        console.warn(`Unable to parse line: "${line}" from "${file}" - skipping...`);
+        s.log('warn', `Unable to parse line: "${line}" from "${file}" - skipping...`);
       }
     }
 
@@ -357,7 +360,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
   // Sanity check on verse numbers for the current chapter
   if (bookObj.header.bookInfo.versesInChapter &&
       verseNum-1 > bookObj.header.bookInfo.versesInChapter[currentChapter]) {
-    console.warn(`${bookObj.header.bookInfo.name} ch ${currentChapter} has ` +
+    s.log('warn', `${bookObj.header.bookInfo.name} ch ${currentChapter} has ` +
       `${verseNum-1} verses, should be ${bookObj.header.bookInfo.versesInChapter[currentChapter]}.`);
   }
 }


### PR DESCRIPTION
Fixes #5 

This addresses user-requested feature to write pertinent log output as a Paratext "Extra Book" (Book code 'XXA').
"Extra Book A" (XXA) to "Extra Book G" (XXG) are non-canonical books that can store miscellaneous content in Paratext.
The book numbers 94 to 100 should match the ones defined at the end of [Paratext Book Identifiers](https://ubsicap.github.io/usfm/identification/books.html)

SFMConsole() is initialized with the project name and the "Extra Book" code. The book code is expected to be between XXA to XXG.

Calls to sfmConsole.log() will output to console and add the text to an internal logging Obj.

sfmConsole.writeLog() then finally writes out the internal logging Obj to the corresponding SFM file.

For this round of changes, I limited use of sfmConsole to flagging:
* Unrecognized line/marker to parse
* Verses in a chapter don't match
