### PR TITLE
Executes 'npm run watch' upon opening the sfm-utils project

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,18 @@
 			],
 			"group": {
 				"kind": "build",
-				 "isDefault": true
+				"isDefault": true
+			}
+		},
+		{
+			"type": "npm",
+			"script": "watch",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: watch",
+			"detail": "npx tsc -w & nodemon -q -w dist",
+      		"runOptions": {
+				"runOn": "folderOpen"
 			}
 		}
 	]


### PR DESCRIPTION
This change in tasks.json means that we won't have to manually run 'npm run build' or 'npm run watch' before running with the most recent changes to the script. Now, every time we open the sfm-utils folder in Visual Studio Code, a shell will be opened and 'npm run watch' started.