### PR TITLE
fix: getBookByNumber() for updated book numbers

### DIFF
--- a/src/books.ts
+++ b/src/books.ts
@@ -902,7 +902,7 @@ export function getBookByName(name: string): bookType {
 
 /**
  * Get the book information given the book number.
- * If the book number doesn't exist or is 0, then exit.
+ * If the book number doesn't exist or is 0, return PLACEHOLDER_BOOK.
  * @param {number} bookNumber
  * @returns {bookType}
  */
@@ -913,7 +913,7 @@ export function getBookByNumber(bookNumber: number) : bookType {
     return book;
   } else {
     console.error(`getBookByNumber(${bookNumber}) does not exist`);
-    process.exit(1);
+    return PLACEHOLDER_BOOK;
   }
 }
 

--- a/src/books.ts
+++ b/src/books.ts
@@ -901,16 +901,19 @@ export function getBookByName(name: string): bookType {
 }
 
 /**
- * Get the book information given the book number (between 1 and 66 inclusive).
+ * Get the book information given the book number.
+ * If the book number doesn't exist or is 0, then exit.
  * @param {number} bookNumber
  * @returns {bookType}
  */
 export function getBookByNumber(bookNumber: number) : bookType {
-  if (bookNumber < 1 || bookNumber > 66) {
-    console.error(`getBookByNumber failed with book number: ${bookNumber}`);
+  const book = bookInfo.find(b => b.num == bookNumber && bookNumber != 0);
+
+  if (book) {
+    return book;
+  } else {
+    console.error(`getBookByNumber(${bookNumber}) does not exist`);
     process.exit(1);
   }
-
-  return bookInfo[bookNumber];
 }
 

--- a/src/books.ts
+++ b/src/books.ts
@@ -902,12 +902,12 @@ export function getBookByName(name: string): bookType {
 
 /**
  * Get the book information given the book number.
- * If the book number doesn't exist or is 0, return PLACEHOLDER_BOOK.
+ * If the book number doesn't exist, return PLACEHOLDER_BOOK.
  * @param {number} bookNumber
  * @returns {bookType}
  */
 export function getBookByNumber(bookNumber: number) : bookType {
-  const book = bookInfo.find(b => b.num == bookNumber && bookNumber != 0);
+  const book = bookInfo.find(b => b.num == bookNumber);
 
   if (book) {
     return book;


### PR DESCRIPTION
    We'll fix books.getBookByNumber() on a separate PR. 
    (Original assumptions changed when adding extra books and renumbering NT books).

_Originally posted by @darcywong00 in https://github.com/mseag/sfm-utils/issues/7#issuecomment-1386658478_

Originally, book numbers were assumed to range from 1 to 66. With the addition of "Extra Books" and renumbering the NT book numbers, `books.getBookByNumber()` can no longer just find the matching index of `books.bookInfo`.


            