### PR TITLE
Additional sfm changes for styling and Linux processing

### DIFF
--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -13,7 +13,7 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
   const ID_MARKER = "\\id ";
   const USFM_MARKER = "\\usfm ";
   const HEADER_MARKER = "\\h ";
-  const TOC_MARKER = "\\toc ";
+  const TOC_MARKER = "\\toc1 ";
   const MAIN_TITLE_MARKER = "\\mt ";
   const CHAPTER_MARKER = "\\c ";
   const SECTION_MARKER = "\\s"; // number gets added later
@@ -34,7 +34,9 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
 
   chapters.forEach(function(chapter) {
     if(chapter.number != 0){
+      // Chapter markers must be followed by paragraph marker for styling in Paratext
       SFMtext += CHAPTER_MARKER + chapter.number + CRLF;
+      SFMtext += PARAGRAPH_MARKER + CRLF;
       if(chapter.content){
         const sectionsAndVerses = chapter.content;
         sectionsAndVerses.forEach(function(unit) {

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -34,9 +34,11 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
 
   chapters.forEach(function(chapter) {
     if(chapter.number != 0){
-      // Chapter markers must be followed by paragraph marker for styling in Paratext
       SFMtext += CHAPTER_MARKER + chapter.number + CRLF;
-      SFMtext += PARAGRAPH_MARKER + CRLF;
+      if (chapter.number == 1) {
+        // For Chapter 1, marker must be followed by paragraph marker for styling in Paratext
+        SFMtext += PARAGRAPH_MARKER + CRLF;
+      }
       if(chapter.content){
         const sectionsAndVerses = chapter.content;
         sectionsAndVerses.forEach(function(unit) {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -125,8 +125,8 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
     s: sfmConsole.SFMConsole, debugMode = false) {
   // Read in Toolbox file and strip out empty lines
   let toolboxFile = fs.readFileSync(file, 'utf-8');
-  toolboxFile = toolboxFile.replace(/(\r\n?){2,}/g, '\r\n');
-  const toolboxData = toolboxFile.split(/\r\n?/);
+  toolboxFile = toolboxFile.replace(/(\r?\n){2,}/g, '\r\n');
+  const toolboxData = toolboxFile.split(/\r?\n/);
   const SECTION_TITLE = 'title.';
   if (toolboxData[toolboxData.length - 1] == '') {
     // If last line empty, remove it


### PR DESCRIPTION
Couple more changes:

Write `\toc1` instead of `\toc`
Write `\p` only on after `\c 1`
Handle splitting the .txt files on Linux