### PR TITLE
fix: Add "\p" if "\c" chapter is followed by "\vs" verse instead of "\s" section header

### DIFF
--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -38,6 +38,11 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
       if (chapter.number == 1) {
         // For Chapter 1, marker must be followed by paragraph marker for styling in Paratext
         SFMtext += PARAGRAPH_MARKER + CRLF;
+      } else {
+        // For other chapters, also insert pargraph marker if there's no section header before verse 1
+        if (chapter?.content && chapter.content[0].type != "section") {
+          SFMtext += PARAGRAPH_MARKER + CRLF;
+        }
       }
       if(chapter.content){
         const sectionsAndVerses = chapter.content;


### PR DESCRIPTION
@sdysart clarified his request as follow-on to #12
* If a `\c` marker is followed by `\s` section header, no need to add `\p` marker
* If a `\c` marker is followed by a `\vs` verse, insert `\p` in between