### PR TITLE
feat: roundtrip SFM data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # sfm-utils
-Utilities to parse text files (e.g. from Toolbox) and migrate SFM markers into a format suitable for Paratext.
-Each book input is written to individual .sfm files.
+Utilities to parse book translations in SFM text files (.txt, .rtf, .sfm) into JSON objects, and then write out the books into SFM suitable for Paratext or .tsv.
+When directories are processed, each book input is written to individual .sfm files.
 
 Assumptions:
 * Each text file is for a single chapter of a book
@@ -13,7 +13,7 @@ Note for developers: Replace `sfm-utils.exe` references with `node dist/index.js
 
 Command-line
 ```bash
-Usage: sfm-utils.exe -p p_arg [-t t_arg | -d d_arg | -j j_arg | -s s_arg]
+Usage: sfm-utils.exe -p p_arg [-f f_arg | -t t_arg | -d d_arg | -j j_arg | -s s_arg]
 ```
 
 Parameters
@@ -21,7 +21,8 @@ Parameters
     Required
     -p [Paratext project name (can be 3-character abbreviation)]
 
-    Optional - one of:
+    Optional for processing txt or sfm files - one of:
+    -f [A single SFM file (can be an entire book)]
     -t [A single Toolbox text file (one chapter of a book)]
     -d [Directory of Toolbox text files for a single book (one chapter per file)]
     -j [JSON file representing a single book - used for testing conversion to SFM]
@@ -34,11 +35,6 @@ Parameters
 ```
 
 ### Help
-Obtaining the sfm-utils version:
-```bash
-sfm-utils.exe --version
-```
-
 For additional help:
 ```bash
 sfm-utils.exe -h
@@ -49,7 +45,7 @@ sfm-utils.exe -h
 
 ## Developer Setup
 These utilities require Git, Node.js, and TypeScript (installed locally).
-Back translations in .rtf text files will also need UnRTF installed for converting the Rich Text format.
+Back translations in .rtf text files will also need UnRTF installed for converting the Rich Text format (only works on Linux).
 
 ### Install Git
 Download and install Git

--- a/src/books.ts
+++ b/src/books.ts
@@ -720,8 +720,8 @@ export const bookInfo: bookType[] = [
     name: "Extra Book E",
     num: 98,
     chapters: 999,
-    versesInChapter: [0],
-    verses: 0
+    versesInChapter: [0, 999],
+    verses: 999
   },
   {
     code: "XXF",
@@ -862,7 +862,7 @@ export function getBookByName(name: string): bookType {
     case 'I Corinthians':
     case '1Corinthians':
     case 'x1Corinthians':
-    case '1 Cor':  
+    case '1 Cor':
       bookName = "1 Corinthians";
       break;
     case '2Corinthians':
@@ -880,9 +880,9 @@ export function getBookByName(name: string): bookType {
       break;
     case 'Phil':
       bookName = 'Philippians';
-      break;  
+      break;
     case '1Thessalonians':
-    case '1 Thess':       
+    case '1 Thess':
       bookName = '1 Thessalonians';
       break;
     case '2Thessalonians':
@@ -890,7 +890,7 @@ export function getBookByName(name: string): bookType {
       bookName = '2 Thessalonians';
       break;
     case '1Timothy':
-    case '1 Tim':  
+    case '1 Tim':
       bookName = '1 Timothy';
       break;
     case '2Timothy':
@@ -898,7 +898,7 @@ export function getBookByName(name: string): bookType {
       bookName = '2 Timothy';
       break;
     case '1Peter':
-    case '1 Pet':  
+    case '1 Pet':
       bookName = '1 Peter';
       break;
     case '2Peter':

--- a/src/books.ts
+++ b/src/books.ts
@@ -743,13 +743,24 @@ export const bookInfo: bookType[] = [
 //#endregion
 
 /**
- * Description of the unit within a chapter.
+ * Description of the unit within a chapter or header.
  */
 export type unitSubtype =
-  "padding" |
-  "chapter" |
-  "verse" |
-  "section";
+  "padding"       |
+
+  // Units in headers
+  "header"        |
+  "toc1"          |
+  "toc2"          |
+  "toc3"          |
+  "main_title"   |
+  "chapter_label" |
+
+  // Units in chapters
+  "chapter"       |
+  "verse"         |
+  "section"       |
+  "paragraph";
 
 export interface unitType {
   type: unitSubtype,
@@ -762,7 +773,8 @@ export interface unitType {
 export interface objType {
   header: {
     projectName: string,
-    bookInfo:  bookType
+    bookInfo:  bookType,
+    markers: unitType[]
   },
   content: unitType[]
 }
@@ -771,7 +783,8 @@ export const PLACEHOLDER_BOOK: bookType = bookInfo[0];
 export const PLACEHOLDER_BOOK_OBJ: objType = {
   "header": {
     "projectName" : "",
-    "bookInfo" : PLACEHOLDER_BOOK
+    "bookInfo" : PLACEHOLDER_BOOK,
+    "markers": []
   },
   "content": []
 }

--- a/src/books.ts
+++ b/src/books.ts
@@ -719,9 +719,9 @@ export const bookInfo: bookType[] = [
     code: "XXE",
     name: "Extra Book E",
     num: 98,
-    chapters: 999,
-    versesInChapter: [0, 999],
-    verses: 999
+    chapters: 1,
+    versesInChapter: [0, 462],
+    verses: 462
   },
   {
     code: "XXF",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { CommanderError, program } from 'commander';
 import * as fs from 'fs';
 import * as backTranslation from './backTranslation.js';
 import * as books from './books.js';
+import * as path from 'path';
 import * as toolbox from './toolbox.js';
 import require from './cjs-require.js';
 import * as sfm from './sfm.js';
@@ -345,6 +346,16 @@ function processText(filepath: string, bookObj: books.objType): books.objType {
 
     //valid JSON Object to SFM
     sfm.convertToSFM(bookObj, s);
+  } else if (options.sfm && bookObj.header.bookInfo.code !== "000") {
+    const basename = path.parse(path.basename(filepath)).name;
+
+    // For testing, write out book JSON Object
+    writeJSON(bookObj, basename + '.json');
+
+    // Move JSON name
+
+    // Write JSON Object to TSV file
+    sfm.convertToTSV(bookObj, basename);
   }
 
   return bookObj;
@@ -380,18 +391,21 @@ async function processJSON(filepath: string){
 
 /**
  * Write JSON file (for testing purposes).
- * Filename will be [##][XYZ][Project name].json
+ * If filename not provided, it will be [##][XYZ][Project name].json
  * ## - 2-digit book number
  * XYZ - 3 character book code
  * Project name - Paratext project name
  * @param {books.bookType} bookObj - the book object to write to file
+ * @param {filename} string - filename to write.
  */
-function writeJSON(bookObj: books.objType) {
+function writeJSON(bookObj: books.objType, filename : string = '') {
   if (debugMode) {
     // Add leading 0 if book number < 10
     const padZero = bookObj.header.bookInfo.num < 10 ? '0' : '';
-    const filename = padZero + bookObj.header.bookInfo.num +
+    if (filename == '') {
+      filename = padZero + bookObj.header.bookInfo.num +
       bookObj.header.bookInfo.code + bookObj.header.projectName + '.json';
+    }
     fs.writeFileSync('./' + filename, JSON.stringify(bookObj, null, 2));
     console.info(`Writing out "${filename}"`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,14 +327,6 @@ function processText(filepath: string, bookObj: books.objType): books.objType {
 
     //valid JSON Object to SFM
     sfm.convertToSFM(bookObj, s);
-  } else if (options.sfm && bookObj.header.bookInfo.code !== "000") {
-    const basename = path.parse(path.basename(filepath)).name;
-
-    // For testing, write out book JSON Object
-    writeJSON(bookObj, basename + '.json');
-
-    // Write JSON Object to TSV file
-    sfm.convertToTSV(bookObj, basename);
   }
 
   return bookObj;
@@ -392,8 +384,13 @@ function processSFMText(filepath: string, bookObj: books.objType): books.objType
     // For testing, write out book JSON Object
     writeJSON(bookObj, basename + '.json');
 
-    //valid JSON Object to SFM
-    sfm.convertToSFM(bookObj, s);
+    if (bookObj.header.bookInfo.code == 'XXE') {
+      // Special SFM file written to TSV
+      sfm.convertToTSV(bookObj, basename);
+    } else {
+      //valid JSON Object to SFM
+      sfm.convertToSFM(bookObj, s);
+    }
   }
 
   return bookObj;

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ if (options.superDirectory && !fs.existsSync(options.superDirectory)) {
 // Validate one of the optional parameters is given
 if (!options.back && !options.sfm && !options.text && !options.backDirectory && !options.directory &&
     !options.json && !options.backSuperDirectory && !options.superDirectory) {
-  console.error("Need to pass another optional parameter [-b -t -bd -d -j -bs or -s]");
+  console.error("Need to pass another optional parameter [-b -f -t -bd -d -j -bs or -s]");
   process.exit(1);
 }
 
@@ -283,25 +283,6 @@ async function processBackText(filepath: string, bookObj: books.objType): Promis
   return bookObj;
 }
 
-function processSFMText(filepath: string, bookObj: books.objType): books.objType {
-  const bookInfo = toolbox.getBookAndChapter(filepath);
-
-  if (bookObj.content.length == 0) {
-    bookObj = toolbox.initializeBookObj(bookInfo.bookName, options.projectName);
-  }
-  const currentChapter = 0; // TODO fix
-  if (!bookObj.content[currentChapter]) {
-    console.error(`${bookInfo.bookName} has insufficent chapters allocated to handle ${currentChapter}. Exiting`);
-    process.exit(1);
-  }
-  if (bookObj.content[currentChapter].type != "chapter") {
-    // Initialize current chapter
-    bookObj.content[currentChapter].type = "chapter";
-    bookObj.content[currentChapter].content = [];
-  }
-
-  return bookObj;
-}
 /**
  * Take a text file and make a JSON book type object
  * @param {string} filepath - file path of a single text file
@@ -351,8 +332,6 @@ function processText(filepath: string, bookObj: books.objType): books.objType {
 
     // For testing, write out book JSON Object
     writeJSON(bookObj, basename + '.json');
-
-    // Move JSON name
 
     // Write JSON Object to TSV file
     sfm.convertToTSV(bookObj, basename);

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -74,3 +74,30 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
   const padZero = bookObj.header.bookInfo.num < 10 ? '0': '';
   fs.writeFileSync('./' + padZero + bookNum + bookCode + projectName + '.SFM', SFMtext);
 }
+
+/**
+ * Parse a JSON file and converts it to TSV
+ * @param {Books.objType} bookObj - a book type of JSON object
+ * @param {string} filepath - the original filename
+ */
+export function convertToTSV(bookObj: books.objType,  filepath: string) {
+  const CRLF = "\n";
+
+  const chapters = bookObj.content;
+
+  let CSVtext = "";
+
+  chapters.forEach(function(chapter) {
+    if(chapter.number != 0) {
+      if(chapter.content){
+        chapter.content.forEach(v => {
+          CSVtext += v.number + '\t' + v.text + CRLF;
+        });
+      }
+    }
+  });
+
+  const padZero = bookObj.header.bookInfo.num < 10 ? '0': '';
+
+  fs.writeFileSync('./' + padZero + filepath + '.TSV', CSVtext);
+}

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -85,19 +85,18 @@ export function convertToTSV(bookObj: books.objType,  filepath: string) {
 
   const chapters = bookObj.content;
 
-  let CSVtext = "";
+  let TSVtext = "";
 
   chapters.forEach(function(chapter) {
     if(chapter.number != 0) {
       if(chapter.content){
         chapter.content.forEach(v => {
-          CSVtext += v.number + '\t' + v.text + CRLF;
+          TSVtext += v.number + '\t' + v.text + CRLF;
         });
       }
     }
   });
 
   const padZero = bookObj.header.bookInfo.num < 10 ? '0': '';
-
-  fs.writeFileSync('./' + padZero + filepath + '.TSV', CSVtext);
+  fs.writeFileSync('./' + padZero + filepath + '.TSV', TSVtext);
 }

--- a/src/sfm.ts
+++ b/src/sfm.ts
@@ -1,8 +1,141 @@
 // Copyright 2022 SIL International
 // Utilities for converting a JSON file to USFM
 import * as books from './books.js';
+import * as toolbox from './toolbox.js';
 import * as sfmConsole from './sfmConsole.js';
 import * as fs from 'fs';
+
+/**
+ * Parse an SFM text file and modify the corresponding
+ * book Object containing the chapter information
+ * @param {book.objType} bookObj - Book object to modify
+ * @param {string} file - Path to the SFM file
+ * @param {sfmConsole.SFMConsole} - Object that maintains logging
+ * @param {boolean} debugMode - Whether to print additional logging
+ */
+export function updateObj(bookObj: books.objType, file: string,
+  s: sfmConsole.SFMConsole, debugMode = false) {
+
+  let currentChapter = 1; // Start with first chapter
+  // Read in SFM file and strip out empty lines
+  let sfmFile = fs.readFileSync(file, 'utf-8');
+  sfmFile = sfmFile.replace(/(\r?\n){2,}/g, '\r\n');
+  const sfmData = sfmFile.split(/\r?\n/);
+  const SECTION_TITLE = 'title.';
+  let section_title_written = false;
+  if (sfmData[sfmData.length - 1] == '') {
+    // If last line empty, remove it
+    sfmData.pop();
+  }
+
+  // Split each line on marker and content
+  const markerPattern = /(\\_?[A-Za-z0-9]+)(\s+)?(.+)?/;
+  let verseNum = 2; // Keep track of the current verse to write
+
+  sfmData.forEach(line => {
+    if (line.trim() === '') {
+      // Skip
+      return;
+    }
+    const lineMatch = line.match(markerPattern);
+    // Skip markers lacking content
+    if (lineMatch && lineMatch[2] != '') {
+      const marker: toolbox.markerType = lineMatch[1] as toolbox.markerType;
+      const content: string = lineMatch[3];
+      const unit: books.unitType = {
+        "type": "padding",
+        "number": verseNum,
+        "text": content
+      };
+
+      // Basic processing mode
+      switch (marker) {
+        case '\\_sh':
+        case '\\ft' :
+        case '\\gl' :
+        case '\\ref' :
+          // Markers to ignore
+          break;
+
+        // Header Markers
+        case '\\h' :
+          unit.type = "header";
+          unit.number = 1;
+          if (content) {
+            unit.text = content;
+          }
+          bookObj.header.markers.push(unit);
+          break;
+        case '\\toc1' :
+        case '\\toc2' :
+        case '\\toc3' :
+          unit.type = marker.substring(1) as books.unitSubtype;
+          unit.number = 1;
+          if (content) {
+            unit.text = content;
+          }
+          bookObj.header.markers.push(unit);
+          break;
+        case '\\mt' :
+          unit.type = "main_title";
+          unit.number = 1;
+          if (content) {
+            unit.text = content;
+          }
+          bookObj.header.markers.push(unit);
+          break;
+        case '\\cl' :
+          unit.type = "chapter_label";
+          unit.number = 1; // Doesn't matter
+          if (content) {
+            unit.text = content;
+          }
+          bookObj.header.markers.push(unit);
+          break;
+
+        // Content markers
+        case '\\c' :
+          // Update to new current chapter
+          currentChapter = parseInt(content);
+          section_title_written = false;
+          break;
+        case '\\s' :
+          // Write section content
+          unit.type = "section";
+          unit.text = content;
+          unit.number = (section_title_written) ? 2 : 1;
+          section_title_written = true;
+
+          // Add section
+          bookObj.content[currentChapter].content.push(unit);
+          break;
+        case '\\v' : {
+          const vPatternMatch = line.trim().match(toolbox.V_PATTERN);
+          if (vPatternMatch) {
+            verseNum = parseInt(vPatternMatch[1]);
+
+            // Write verse
+            unit.type = "verse";
+            unit.number = verseNum;
+            unit.text = vPatternMatch[2];
+            bookObj.content[currentChapter].content.push(unit);
+          }
+          break;
+        }
+        case '\\p' : {
+          // Write paragraph
+          unit.type = "paragraph";
+          unit.number = 1; // number doesn't matter
+          unit.text = lineMatch[3] ? lineMatch[3] : '';
+          bookObj.content[currentChapter].content.push(unit);
+          break;
+        }
+        default:
+          console.warn('Skipping unexpected marker:' + marker);
+      }
+    }
+  });
+}
 
 /**
  * Parse a JSON file and converts it to USFM
@@ -13,25 +146,57 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
   const ID_MARKER = "\\id ";
   const USFM_MARKER = "\\usfm ";
   const HEADER_MARKER = "\\h ";
-  const TOC_MARKER = "\\toc1 ";
+  const TOC1_MARKER = "\\toc1 ";
+  const TOC2_MARKER = "\\toc2 ";
+  const TOC3_MARKER = "\\toc3 ";
   const MAIN_TITLE_MARKER = "\\mt ";
   const CHAPTER_MARKER = "\\c ";
+  const CHAPTER_LABEL_MARKER = "\\cl ";
   const SECTION_MARKER = "\\s"; // number gets added later
   const PARAGRAPH_MARKER = "\n\\p";
   const VERSE_MARKER = "\\v ";
   const CRLF = "\n";
 
-  const chapters = bookObj.content;
 
   let SFMtext = "";
 
+  // These were the initial header
+  /*
   SFMtext += ID_MARKER + bookObj.header.bookInfo.code + ' ' +  bookObj.header.projectName + CRLF;
   SFMtext += USFM_MARKER + '3.0' + CRLF;
   SFMtext += HEADER_MARKER + bookObj.header.bookInfo.name + CRLF;
-  SFMtext += TOC_MARKER + bookObj.header.bookInfo.name + CRLF;
+  SFMtext += TOC1_MARKER + bookObj.header.bookInfo.name + CRLF;
   SFMtext += MAIN_TITLE_MARKER + bookObj.header.bookInfo.name + CRLF;
+  */
 
+  SFMtext += ID_MARKER + bookObj.header.bookInfo.code + ' ' +  bookObj.header.projectName + CRLF;
+  bookObj.header.markers.forEach(function(marker) {
+    const text = marker.text ? marker.text : '';
+    switch(marker.type) {
+      case "header" :
+        SFMtext += HEADER_MARKER + text + CRLF;
+        break;
+      case "toc1" :
+        SFMtext += TOC1_MARKER + text + CRLF;
+        break;
+      case "toc2" :
+        SFMtext += TOC2_MARKER + text + CRLF;
+        break;
+      case "toc3" :
+        SFMtext += TOC3_MARKER + text + CRLF;
+        break;
+      case "main_title" :
+        SFMtext += MAIN_TITLE_MARKER + text + CRLF;
+        break;
+      case "chapter_label" :
+        SFMtext += CHAPTER_LABEL_MARKER + text + CRLF;
+        break;
+      default:
+        throw 'Invalid type on ' + JSON.stringify(marker) + '. \nUnexpected header marker.';
+    }
+  })
 
+  const chapters = bookObj.content;
   chapters.forEach(function(chapter) {
     if(chapter.number != 0){
       SFMtext += CHAPTER_MARKER + chapter.number + CRLF;
@@ -58,6 +223,11 @@ export function convertToSFM(bookObj: books.objType,  s: sfmConsole.SFMConsole) 
                 SFMtext += VERSE_MARKER + unit.number + '-' + unit.bridgeEnd + ' ' + unit.text + CRLF;
               }
               break;
+            case "paragraph": {
+              const text = unit.text != '' ? ' ' + unit.text : '';
+              SFMtext += PARAGRAPH_MARKER + text + CRLF;
+              break;
+            }
             default:
               throw 'Invalid type on ' + JSON.stringify(unit) + '. \nLooking for "section" or "verse".';
           }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -12,7 +12,7 @@ import * as sfmConsole from './sfmConsole.js';
  * VS_AS_VERSE - `\vs` marks verse numbers along with section headers.
  *               Uses the state machine (actions)
  */
-type modeType =
+export type modeType =
   "TX_AS_VERSE" |
   "VS_AS_VERSE" |
   "V_AS_VERSE";
@@ -34,14 +34,21 @@ type actionType =
  */
 export type markerType =
   // These are processed
-  "\\tx" |
-  "\\vs" |
-  "\\v"  |
+  "\\tx"   |
+  "\\vs"   |
+  "\\v"    |
+  "\\s"    |
+  "\\p"    |
+  "\\h"    |
+  "\\toc3" |
+  "\\toc1" |
+  "\\toc2" |
+  "\\mt"   |
+  "\\cl"   |
 
   // These are ignored
   "\\_sh" |
   "\\c" |
-  "\\cl" |
   "\\ft" |
   "\\gl" |
   "\\ref" |
@@ -163,7 +170,8 @@ export function initializeBookObj(bookName: string, projectName: string) : books
   const bookObj : books.objType = {
     "header": {
       "projectName" : projectName,
-      "bookInfo" : bookType
+      "bookInfo" : bookType,
+      "markers": [],
     },
     "content": []
   };

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -208,6 +208,7 @@ export function updateObj(bookObj: books.objType, file: string, currentChapter: 
   const modePatternV = /\\v\s+\d+.*/;
   toolboxData.every(line => {
     if (line.match(modePatternVS)) {
+      // Change mode and break out
       mode = 'VS_AS_VERSE';
       return false;
     } else if (line.match(modePatternV)) {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -111,8 +111,13 @@ export function getVerseBridge(line: string, verseNum: number) : bridgeType {
  */
 export function getBookAndChapter(file: string) : fileInfoType {
   const filename = path.parse(file).base;
+
   const pattern = /([0-9A-Za-z]+)_(Ch|ch)?(\d+)[_\s]?.*\.txt/;
   const match = filename.match(pattern);
+
+  const patternSFM = /([0-9]{2})([0-9A-Za-z]{3}).+\.(SFM|sfm)/;
+  const matchSFM = filename.match(patternSFM);
+
   const obj: fileInfoType = {
     bookName: "Placeholder",
     chapterNumber: 0
@@ -123,6 +128,14 @@ export function getBookAndChapter(file: string) : fileInfoType {
     if (bookName !== "Placeholder") {
       obj.bookName = bookName;
       obj.chapterNumber = parseInt(match[3]);
+    }
+   // Attempt to parse SFM file name
+  } else if (matchSFM) {
+    const bookCode = matchSFM[2] as books.CodeType;
+    const bookName = books.getBookByCode(bookCode).name;
+    if (bookName !== "Placeholder") {
+      obj.bookName = bookName;
+      // obj.chapterNumber TODO
     }
   } else {
     console.warn('Unable to determine info from: ' + filename);


### PR DESCRIPTION
This is a starting point for round-tripping SFM content (SFM to JSON and back to SFM).

One user had SFM data from multiple files in "Extra Book E" and wanted them collated into a spreadsheet. Each file is treated as a single chapter, with the "verse number" starting with 2 (hard-coded in sfm.ts and toolbox.ts).

Another project may be interested in having some SFM parsing utilities.

Added command-line argument `-f` to parse a single SFM file.

